### PR TITLE
Wire frasermolyneux-copilot MCP server into repo

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -145,3 +145,9 @@ Consumers resolve settings with: **per-server override → global config → bui
 - `XtremeIdiots.Portal.ChatCommands.Abstractions.V1` is compatibility-only during migration and must not be used as the canonical settings contract source for new work.
 - Compatibility-shim removal is gated by cross-repo migration evidence; do not remove shims until gate criteria are met and recorded.
 - Compatibility transition and troubleshooting guidance is documented in `docs/settings-contracts-compatibility-shim.md`.
+
+## Org conventions via MCP (when available)
+
+If a `frasermolyneux-copilot` MCP server is configured in your client (`.vscode/mcp.json`, the GitHub Copilot coding-agent MCP config at `.github/copilot/mcp_config.json`, or an equivalent stdio MCP wire-up), **prefer its tools** over your own assumptions when answering questions about org standards, branching, workflows, Terraform, .NET projects, Azure patterns, or shared library / platform consumption contracts. The tool surface is `list_instructions`, `get_instruction`, `search_instructions`, plus the matching `_prompts` and `_agents` equivalents (seven tools total). The catalog source-of-truth lives in `frasermolyneux/.github-copilot` — see `mcp-server/README.md` there for the tool contract.
+
+This is **complementary** to the file-load model: if `./.github-copilot/` is checked out in the runner (per `copilot-setup-steps.yml`), continue to read those files directly. If both are available, prefer MCP for freshness. If no MCP server is configured in your client, treat this section as a no-op and fall back to the file paths above.

--- a/.github/copilot/mcp_config.json
+++ b/.github/copilot/mcp_config.json
@@ -1,0 +1,13 @@
+{
+  "mcpServers": {
+    "frasermolyneux-copilot": {
+      "type": "local",
+      "command": "node",
+      "args": [".github-copilot/mcp-server/dist/index.js"],
+      "env": {
+        "GH_COPILOT_CONTENT_ROOT": ".github-copilot"
+      },
+      "tools": ["*"]
+    }
+  }
+}

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -34,7 +34,19 @@ jobs:
         uses: actions/checkout@v6
         with:
           repository: frasermolyneux/.github-copilot
+          ref: refs/tags/v0.1.0
           path: .github-copilot
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 20.x
+
+      - name: Build MCP server
+        working-directory: .github-copilot/mcp-server
+        run: |
+          npm ci
+          npm run build
 
       - name: Setup .NET
         uses: actions/setup-dotnet@v5

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -129,3 +129,9 @@ Stop and escalate when:
 - The Database project requires a destructive schema migration (data loss risk).
 - A `code-review` finding is **High** and cannot be resolved in-scope.
 - APIM import would require manual product / policy coordination beyond the workflow.
+
+## Org conventions via MCP (when available)
+
+If a `frasermolyneux-copilot` MCP server is configured in your client (`.vscode/mcp.json`, the GitHub Copilot coding-agent MCP config at `.github/copilot/mcp_config.json`, or an equivalent stdio MCP wire-up), **prefer its tools** over your own assumptions when answering questions about org standards, branching, workflows, Terraform, .NET projects, Azure patterns, or shared library / platform consumption contracts. The tool surface is `list_instructions`, `get_instruction`, `search_instructions`, plus the matching `_prompts` and `_agents` equivalents (seven tools total). The catalog source-of-truth lives in `frasermolyneux/.github-copilot` — see `mcp-server/README.md` there for the tool contract.
+
+This is **complementary** to the file-load model: if `./.github-copilot/` is checked out in the runner (per `copilot-setup-steps.yml`), continue to read those files directly. If both are available, prefer MCP for freshness. If no MCP server is configured in your client, treat this section as a no-op and fall back to the file paths above.

--- a/README.md
+++ b/README.md
@@ -29,3 +29,6 @@ Please read the [contributing](CONTRIBUTING.md) guidance; this is a learning and
 
 ## Security
 Please read the [security](SECURITY.md) guidance; I am always open to security feedback through email or opening an issue.
+
+## Local dev: MCP wire-up
+This repo wires the shared `frasermolyneux-copilot` MCP server (catalog of org instructions, prompts, and agents) into the GitHub Copilot coding agent via `.github/copilot/mcp_config.json`. The server is built in `copilot-setup-steps.yml` after checking out `frasermolyneux/.github-copilot` at tag `v0.1.0`. For client wire-up details (VS Code, Claude Desktop, Copilot CLI), tool surface, and content-root resolution, see `.github-copilot/mcp-server/README.md` in [frasermolyneux/.github-copilot](https://github.com/frasermolyneux/.github-copilot).


### PR DESCRIPTION
## Summary

Wires the shared `frasermolyneux-copilot` MCP server into this repo so the GitHub Copilot coding agent can call the org instructions/prompts/agents catalog at runtime. Matches the template already merged to `portal-core` and pins the shared config to tag `v0.1.0` of `frasermolyneux/.github-copilot`.

Closes #

## Type of change

- [ ] bugfix
- [ ] feature
- [x] chore / refactor
- [x] docs
- [x] ci (GitHub Actions / Dependabot)
- [ ] infra (Terraform)
- [ ] dependencies
- [ ] breaking change

## Required reading consulted

- [x] `AGENTS.md` (repo brief)
- [x] `.github/copilot-instructions.md` (repo orientation)
- [x] `.github-copilot/.github/instructions/personal.working-preferences.instructions.md` (always-on rules)
- [x] Stack-specific instruction files referenced in `AGENTS.md`

## Validation evidence

### Build

```text
N/A — config/docs only, no source compiled. Repo build untouched.
```

### Tests

```text
N/A — config/docs only, no test surface changed.
```

### Format check

```text
JSON: ConvertFrom-Json .github/copilot/mcp_config.json → ok
YAML: python -c "import yaml; yaml.safe_load(open('.github/workflows/copilot-setup-steps.yml'))" → exit 0
```

### Other (sha256 verification of canonical snippet)

```text
.github/copilot-instructions.md → snippet sha256 prefix DDAC8AA449794730 ✓
AGENTS.md                        → snippet sha256 prefix DDAC8AA449794730 ✓
Both files byte-identical at the snippet block (1096 UTF-8 bytes, CRLF).
```

## Risk and rollout

- **Blast radius:** Repo tooling only — affects the Copilot coding agent runner (`copilot-setup-steps.yml`) and agent-facing docs. No runtime, no infra, no published contracts.
- **Auto-deploys on merge?** No.
- **Manual steps post-merge:** None.
- **Rollback plan:** Revert the merge commit. The added `npm ci && npm run build` step is the only new failure surface; if `frasermolyneux/.github-copilot@v0.1.0` ever stops building, pin to a later tag or revert.

## Consumer impact

N/A — no published contract (Abstractions, Api.Client packages, Service Bus DTOs, Terraform outputs) touched.

## Reviewer focus areas

- The `ref: refs/tags/v0.1.0` pin on the existing `frasermolyneux/.github-copilot` checkout — previously unpinned (drifting against `main`); aligning with the template adds the pin.
- The bootstrap snippet in `AGENTS.md` and `.github/copilot-instructions.md` is canonical text fetched via the MCP server itself (`get_instruction metadata.copilot-instructions`); please do not reword.

## Agent attestation

- [x] Ran `code-review` sub-agent; High/Medium findings resolved or justified (one Medium re snippet hash was a CRLF/LF normalization false positive — direct byte-offset extraction at the file's actual encoding yields the spec hash `DDAC8AA449794730`).
- [x] PR body cites each acceptance criterion from the linked issue (5 file changes per the task brief, all applied and verified).
- [x] No client secrets, GUIDs, connection strings, or hard-coded subscription IDs introduced.