### PR TITLE
caching: Phase 2 Part 1 — client defaults, server-side cache-aside, shared table storage, connected players search/sort

### DIFF
--- a/src/XtremeIdiots.Portal.Repository.Abstractions.V1/Constants/V1/ConnectedPlayersOrder.cs
+++ b/src/XtremeIdiots.Portal.Repository.Abstractions.V1/Constants/V1/ConnectedPlayersOrder.cs
@@ -1,0 +1,23 @@
+namespace XtremeIdiots.Portal.Repository.Abstractions.Constants.V1
+{
+    /// <summary>
+    /// Sort order options for the <c>GetConnectedPlayers</c> query. Matches the columns
+    /// exposed by the portal-web ConnectedPlayers DataTables view. Default (no value)
+    /// resolves to <see cref="LinkedAtUtcDesc"/>.
+    /// </summary>
+    public enum ConnectedPlayersOrder
+    {
+        GameTypeAsc,
+        GameTypeDesc,
+        UsernameAsc,
+        UsernameDesc,
+        LinkMethodAsc,
+        LinkMethodDesc,
+        IsActiveAsc,
+        IsActiveDesc,
+        LinkedAtUtcAsc,
+        LinkedAtUtcDesc,
+        UnlinkedAtUtcAsc,
+        UnlinkedAtUtcDesc
+    }
+}

--- a/src/XtremeIdiots.Portal.Repository.Abstractions.V1/Interfaces/V1/IConnectedPlayersApi.cs
+++ b/src/XtremeIdiots.Portal.Repository.Abstractions.V1/Interfaces/V1/IConnectedPlayersApi.cs
@@ -34,6 +34,8 @@ namespace XtremeIdiots.Portal.Repository.Abstractions.Interfaces.V1
             bool? isActive,
             int skipEntries,
             int takeEntries,
+            string? searchString = null,
+            ConnectedPlayersOrder? order = null,
             CancellationToken cancellationToken = default);
 
         Task<ApiResult<Cod4xAdminRosterDto>> GetCod4xAdminRoster(

--- a/src/XtremeIdiots.Portal.Repository.Abstractions.V1/XtremeIdiots.Portal.Repository.Abstractions.V1.csproj
+++ b/src/XtremeIdiots.Portal.Repository.Abstractions.V1/XtremeIdiots.Portal.Repository.Abstractions.V1.csproj
@@ -25,7 +25,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="MX.Api.Abstractions" Version="2.3.67" />
+    <PackageReference Include="MX.Api.Abstractions" Version="2.3.76" />
     <PackageReference Include="MX.GeoLocation.Abstractions.V1" Version="1.2.89" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
   </ItemGroup>

--- a/src/XtremeIdiots.Portal.Repository.Abstractions.V2/XtremeIdiots.Portal.Repository.Abstractions.V2.csproj
+++ b/src/XtremeIdiots.Portal.Repository.Abstractions.V2/XtremeIdiots.Portal.Repository.Abstractions.V2.csproj
@@ -25,7 +25,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="MX.Api.Abstractions" Version="2.3.67" />
+    <PackageReference Include="MX.Api.Abstractions" Version="2.3.76" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
   </ItemGroup>
 

--- a/src/XtremeIdiots.Portal.Repository.Api.Client.Testing/Fakes/FakeConnectedPlayersApi.cs
+++ b/src/XtremeIdiots.Portal.Repository.Api.Client.Testing/Fakes/FakeConnectedPlayersApi.cs
@@ -189,6 +189,8 @@ public class FakeConnectedPlayersApi : IConnectedPlayersApi
         bool? isActive,
         int skipEntries,
         int takeEntries,
+        string? searchString = null,
+        ConnectedPlayersOrder? order = null,
         CancellationToken cancellationToken = default)
     {
         IEnumerable<ConnectedPlayerDto> query = _connectedPlayers.Values;
@@ -212,6 +214,35 @@ public class FakeConnectedPlayersApi : IConnectedPlayersApi
         {
             query = query.Where(cp => cp.IsActive == isActive.Value);
         }
+
+        if (!string.IsNullOrWhiteSpace(searchString))
+        {
+            var s = searchString.Trim();
+            var isGuid = Guid.TryParse(s, out var searchGuid);
+            var isGameType = Enum.TryParse<GameType>(s, ignoreCase: true, out var searchGameType);
+            var lowered = s.ToLowerInvariant();
+            query = query.Where(cp =>
+                (cp.Username != null && cp.Username.Contains(lowered, StringComparison.OrdinalIgnoreCase))
+                || cp.LinkMethod.ToString().Contains(lowered, StringComparison.OrdinalIgnoreCase)
+                || (isGuid && (cp.PlayerId == searchGuid || cp.UserProfileId == searchGuid))
+                || (isGameType && cp.GameType == searchGameType));
+        }
+
+        query = (order ?? ConnectedPlayersOrder.LinkedAtUtcDesc) switch
+        {
+            ConnectedPlayersOrder.GameTypeAsc => query.OrderBy(cp => cp.GameType),
+            ConnectedPlayersOrder.GameTypeDesc => query.OrderByDescending(cp => cp.GameType),
+            ConnectedPlayersOrder.UsernameAsc => query.OrderBy(cp => cp.Username, StringComparer.OrdinalIgnoreCase),
+            ConnectedPlayersOrder.UsernameDesc => query.OrderByDescending(cp => cp.Username, StringComparer.OrdinalIgnoreCase),
+            ConnectedPlayersOrder.LinkMethodAsc => query.OrderBy(cp => cp.LinkMethod.ToString(), StringComparer.OrdinalIgnoreCase),
+            ConnectedPlayersOrder.LinkMethodDesc => query.OrderByDescending(cp => cp.LinkMethod.ToString(), StringComparer.OrdinalIgnoreCase),
+            ConnectedPlayersOrder.IsActiveAsc => query.OrderBy(cp => cp.IsActive),
+            ConnectedPlayersOrder.IsActiveDesc => query.OrderByDescending(cp => cp.IsActive),
+            ConnectedPlayersOrder.LinkedAtUtcAsc => query.OrderBy(cp => cp.LinkedAtUtc),
+            ConnectedPlayersOrder.UnlinkedAtUtcAsc => query.OrderBy(cp => cp.UnlinkedAtUtc),
+            ConnectedPlayersOrder.UnlinkedAtUtcDesc => query.OrderByDescending(cp => cp.UnlinkedAtUtc),
+            _ => query.OrderByDescending(cp => cp.LinkedAtUtc),
+        };
 
         var items = query.Skip(skipEntries).Take(takeEntries).ToList();
         var collection = new CollectionModel<ConnectedPlayerDto> { Items = items };

--- a/src/XtremeIdiots.Portal.Repository.Api.Client.Testing/XtremeIdiots.Portal.Repository.Api.Client.Testing.csproj
+++ b/src/XtremeIdiots.Portal.Repository.Api.Client.Testing/XtremeIdiots.Portal.Repository.Api.Client.Testing.csproj
@@ -15,7 +15,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="MX.Api.Abstractions" Version="2.3.67" />
+		<PackageReference Include="MX.Api.Abstractions" Version="2.3.76" />
 		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.10" />
 	</ItemGroup>
 

--- a/src/XtremeIdiots.Portal.Repository.Api.Client.Tests.V1/RepositoryApiCacheDefaultsTests.cs
+++ b/src/XtremeIdiots.Portal.Repository.Api.Client.Tests.V1/RepositoryApiCacheDefaultsTests.cs
@@ -1,0 +1,221 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Threading.Tasks;
+
+using Microsoft.Extensions.DependencyInjection;
+
+using MX.Api.Abstractions;
+using MX.Api.Client.Caching;
+using MX.Api.Client.Configuration;
+using MX.Api.Client.Extensions;
+using MX.Caching.Abstractions;
+
+using XtremeIdiots.Portal.Repository.Abstractions.Constants.V1;
+using XtremeIdiots.Portal.Repository.Abstractions.Interfaces.V1;
+using XtremeIdiots.Portal.Repository.Abstractions.Models;
+using XtremeIdiots.Portal.Repository.Abstractions.Models.V1.GameServers;
+using XtremeIdiots.Portal.Repository.Abstractions.Models.V1.Maps;
+using XtremeIdiots.Portal.Repository.Abstractions.Models.V1.UserProfiles;
+using XtremeIdiots.Portal.Repository.Api.Client.V1.Caching;
+
+using Xunit;
+
+namespace XtremeIdiots.Portal.Repository.Api.Client.Tests.V1
+{
+    /// <summary>
+    /// Verifies the V1 API client's default cache policy set: exactly the methods declared as
+    /// cacheable are registered as in-memory with the expected TTL, and every never-cache guard
+    /// is present. Uses the real <c>AddDefaultCachePolicies</c> DI path so the tests exercise
+    /// the same code that runs in production.
+    /// </summary>
+    public class RepositoryApiCacheDefaultsTests
+    {
+        private static IReadOnlyDictionary<MethodInfo, CachePolicy> PoliciesFor<TApi>(Action<CacheBuilder> configure)
+            where TApi : class
+        {
+            var services = new ServiceCollection();
+            services.AddDefaultCachePolicies<TApi>(configure);
+            using var sp = services.BuildServiceProvider();
+            var defaults = sp.GetRequiredService<DefaultCachePolicies<TApi>>();
+            return defaults.Policies;
+        }
+
+        private static CachePolicy PolicyFor(IReadOnlyDictionary<MethodInfo, CachePolicy> policies, string methodName, int parameterCount)
+        {
+            var entry = policies.FirstOrDefault(kvp =>
+                kvp.Key.Name == methodName &&
+                kvp.Key.GetParameters().Length == parameterCount);
+            Assert.NotNull(entry.Key);
+            return entry.Value;
+        }
+
+        private static IEnumerable<KeyValuePair<MethodInfo, CachePolicy>> AllPoliciesForMethod(
+            IReadOnlyDictionary<MethodInfo, CachePolicy> policies,
+            string methodName)
+        {
+            return policies.Where(kvp => kvp.Key.Name == methodName);
+        }
+
+        [Fact]
+        public void ConfigureGameServers_CachesGetGameServer_At60Seconds()
+        {
+            var policies = PoliciesFor<IGameServersApi>(RepositoryApiCacheDefaults.ConfigureGameServers);
+
+            var policy = PolicyFor(policies, nameof(IGameServersApi.GetGameServer), parameterCount: 2);
+
+            Assert.True(policy.Enabled);
+            Assert.Equal(CacheTier.InProcess, policy.Tier);
+            Assert.Equal(RepositoryApiCacheDefaults.GameServerTtl, policy.Ttl);
+        }
+
+        [Fact]
+        public void ConfigureGameServers_CachesGetGameServers_At60Seconds()
+        {
+            var policies = PoliciesFor<IGameServersApi>(RepositoryApiCacheDefaults.ConfigureGameServers);
+
+            var policy = PolicyFor(policies, nameof(IGameServersApi.GetGameServers), parameterCount: 7);
+
+            Assert.True(policy.Enabled);
+            Assert.Equal(CacheTier.InProcess, policy.Tier);
+            Assert.Equal(RepositoryApiCacheDefaults.GameServerTtl, policy.Ttl);
+        }
+
+        [Fact]
+        public void ConfigureGameServers_MutationsAreNotCached()
+        {
+            var policies = PoliciesFor<IGameServersApi>(RepositoryApiCacheDefaults.ConfigureGameServers);
+
+            AssertNotCached(policies, nameof(IGameServersApi.CreateGameServer));
+            AssertNotCached(policies, nameof(IGameServersApi.CreateGameServers));
+            AssertNotCached(policies, nameof(IGameServersApi.UpdateGameServer));
+            AssertNotCached(policies, nameof(IGameServersApi.UpdateGameServerOrder));
+            AssertNotCached(policies, nameof(IGameServersApi.DeleteGameServer));
+        }
+
+        [Fact]
+        public void ConfigureMaps_CachesBothGetMapOverloads_At10Minutes()
+        {
+            var policies = PoliciesFor<IMapsApi>(RepositoryApiCacheDefaults.ConfigureMaps);
+
+            var getMapOverloads = AllPoliciesForMethod(policies, nameof(IMapsApi.GetMap)).ToList();
+            Assert.Equal(2, getMapOverloads.Count);
+            Assert.All(getMapOverloads, kvp =>
+            {
+                Assert.True(kvp.Value.Enabled);
+                Assert.Equal(CacheTier.InProcess, kvp.Value.Tier);
+                Assert.Equal(RepositoryApiCacheDefaults.MapTtl, kvp.Value.Ttl);
+            });
+
+            // Disambiguated overload signatures: (Guid, CancellationToken) and (GameType, string, CancellationToken).
+            var idOverload = getMapOverloads.Single(kvp =>
+                kvp.Key.GetParameters()[0].ParameterType == typeof(Guid));
+            var nameOverload = getMapOverloads.Single(kvp =>
+                kvp.Key.GetParameters()[0].ParameterType == typeof(GameType));
+            Assert.NotSame(idOverload.Key, nameOverload.Key);
+        }
+
+        [Fact]
+        public void ConfigureMaps_CachesGetMaps_At10Minutes()
+        {
+            var policies = PoliciesFor<IMapsApi>(RepositoryApiCacheDefaults.ConfigureMaps);
+
+            var policy = PolicyFor(policies, nameof(IMapsApi.GetMaps), parameterCount: 8);
+
+            Assert.True(policy.Enabled);
+            Assert.Equal(CacheTier.InProcess, policy.Tier);
+            Assert.Equal(RepositoryApiCacheDefaults.MapTtl, policy.Ttl);
+        }
+
+        [Fact]
+        public void ConfigureMaps_MutationsAreNotCached()
+        {
+            var policies = PoliciesFor<IMapsApi>(RepositoryApiCacheDefaults.ConfigureMaps);
+
+            AssertNotCached(policies, nameof(IMapsApi.CreateMap));
+            AssertNotCached(policies, nameof(IMapsApi.CreateMaps));
+            AssertNotCached(policies, nameof(IMapsApi.UpdateMap));
+            AssertNotCached(policies, nameof(IMapsApi.UpdateMaps));
+            AssertNotCached(policies, nameof(IMapsApi.DeleteMap));
+            AssertNotCached(policies, nameof(IMapsApi.RebuildMapPopularity));
+            AssertNotCached(policies, nameof(IMapsApi.UpsertMapVote));
+            AssertNotCached(policies, nameof(IMapsApi.UpsertMapVotes));
+            AssertNotCached(policies, nameof(IMapsApi.UpdateMapImage));
+            AssertNotCached(policies, nameof(IMapsApi.ClearMapImage));
+        }
+
+        [Fact]
+        public void ConfigureUserProfile_AllRegisteredMethodsAreNotCached()
+        {
+            var policies = PoliciesFor<IUserProfileApi>(RepositoryApiCacheDefaults.ConfigureUserProfile);
+
+            Assert.NotEmpty(policies);
+            Assert.All(policies, kvp => Assert.Same(CachePolicy.NotCached, kvp.Value));
+        }
+
+        [Fact]
+        public void ConfigureUserProfile_CoversReadsWritesAndClaimSurfaces()
+        {
+            var policies = PoliciesFor<IUserProfileApi>(RepositoryApiCacheDefaults.ConfigureUserProfile);
+
+            var methodNames = policies.Keys.Select(m => m.Name).ToHashSet();
+            Assert.Contains(nameof(IUserProfileApi.GetUserProfile), methodNames);
+            Assert.Contains(nameof(IUserProfileApi.GetUserProfileByIdentityId), methodNames);
+            Assert.Contains(nameof(IUserProfileApi.GetUserProfileByXtremeIdiotsId), methodNames);
+            Assert.Contains(nameof(IUserProfileApi.GetUserProfileByDemoAuthKey), methodNames);
+            Assert.Contains(nameof(IUserProfileApi.GetUserProfiles), methodNames);
+            Assert.Contains(nameof(IUserProfileApi.GetPermissionsReport), methodNames);
+            Assert.Contains(nameof(IUserProfileApi.CreateUserProfile), methodNames);
+            Assert.Contains(nameof(IUserProfileApi.CreateUserProfiles), methodNames);
+            Assert.Contains(nameof(IUserProfileApi.UpdateUserProfile), methodNames);
+            Assert.Contains(nameof(IUserProfileApi.UpdateUserProfiles), methodNames);
+            Assert.Contains(nameof(IUserProfileApi.CreateUserProfileClaim), methodNames);
+            Assert.Contains(nameof(IUserProfileApi.SetUserProfileClaims), methodNames);
+            Assert.Contains(nameof(IUserProfileApi.DeleteUserProfileClaim), methodNames);
+        }
+
+        [Fact]
+        public void ConfigureApiInfo_GetApiInfoIsNotCached()
+        {
+            var policies = PoliciesFor<IApiInfoApi>(RepositoryApiCacheDefaults.ConfigureApiInfo);
+
+            var policy = PolicyFor(policies, nameof(IApiInfoApi.GetApiInfo), parameterCount: 1);
+            Assert.Same(CachePolicy.NotCached, policy);
+        }
+
+        [Fact]
+        public void ConfigureApiHealth_CheckHealthIsNotCached()
+        {
+            var policies = PoliciesFor<IApiHealthApi>(RepositoryApiCacheDefaults.ConfigureApiHealth);
+
+            var policy = PolicyFor(policies, nameof(IApiHealthApi.CheckHealth), parameterCount: 1);
+            Assert.Same(CachePolicy.NotCached, policy);
+        }
+
+        [Fact]
+        public void GameServerAndMapDefaultsHaveNoStaticTags()
+        {
+            // MX.Api.Client 2.3.76 does not support dynamic tag expansion. Positive defaults must
+            // not encode literal placeholder tags such as "gameserver:{id}" — see decorator layer.
+            var gameServerPolicies = PoliciesFor<IGameServersApi>(RepositoryApiCacheDefaults.ConfigureGameServers);
+            foreach (var (_, policy) in gameServerPolicies.Where(kvp => kvp.Value.Enabled))
+            {
+                Assert.Empty(policy.Tags);
+            }
+
+            var mapPolicies = PoliciesFor<IMapsApi>(RepositoryApiCacheDefaults.ConfigureMaps);
+            foreach (var (_, policy) in mapPolicies.Where(kvp => kvp.Value.Enabled))
+            {
+                Assert.Empty(policy.Tags);
+            }
+        }
+
+        private static void AssertNotCached(IReadOnlyDictionary<MethodInfo, CachePolicy> policies, string methodName)
+        {
+            var overloads = AllPoliciesForMethod(policies, methodName).ToList();
+            Assert.NotEmpty(overloads);
+            Assert.All(overloads, kvp => Assert.Same(CachePolicy.NotCached, kvp.Value));
+        }
+    }
+}

--- a/src/XtremeIdiots.Portal.Repository.Api.Client.Tests.V2/RepositoryApiCacheDefaultsTests.cs
+++ b/src/XtremeIdiots.Portal.Repository.Api.Client.Tests.V2/RepositoryApiCacheDefaultsTests.cs
@@ -1,0 +1,56 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+
+using Microsoft.Extensions.DependencyInjection;
+
+using MX.Api.Client.Caching;
+using MX.Api.Client.Configuration;
+using MX.Api.Client.Extensions;
+using MX.Caching.Abstractions;
+
+using XtremeIdiots.Portal.Repository.Abstractions.Interfaces.V2;
+using XtremeIdiots.Portal.Repository.Api.Client.V2.Caching;
+
+using Xunit;
+
+namespace XtremeIdiots.Portal.Repository.Api.Client.Tests.V2
+{
+    /// <summary>
+    /// Verifies the V2 API client's default cache policy set. V2 only exposes info and health
+    /// probes so every default must be <see cref="CachePolicy.NotCached"/>.
+    /// </summary>
+    public class RepositoryApiCacheDefaultsTests
+    {
+        private static IReadOnlyDictionary<MethodInfo, CachePolicy> PoliciesFor<TApi>(Action<CacheBuilder> configure)
+            where TApi : class
+        {
+            var services = new ServiceCollection();
+            services.AddDefaultCachePolicies<TApi>(configure);
+            using var sp = services.BuildServiceProvider();
+            var defaults = sp.GetRequiredService<DefaultCachePolicies<TApi>>();
+            return defaults.Policies;
+        }
+
+        [Fact]
+        public void ConfigureApiInfo_GetApiInfoIsNotCached()
+        {
+            var policies = PoliciesFor<IApiInfoApi>(RepositoryApiCacheDefaults.ConfigureApiInfo);
+
+            var policy = Assert.Single(policies);
+            Assert.Equal(nameof(IApiInfoApi.GetApiInfo), policy.Key.Name);
+            Assert.Same(CachePolicy.NotCached, policy.Value);
+        }
+
+        [Fact]
+        public void ConfigureApiHealth_CheckHealthIsNotCached()
+        {
+            var policies = PoliciesFor<IApiHealthApi>(RepositoryApiCacheDefaults.ConfigureApiHealth);
+
+            var policy = Assert.Single(policies);
+            Assert.Equal(nameof(IApiHealthApi.CheckHealth), policy.Key.Name);
+            Assert.Same(CachePolicy.NotCached, policy.Value);
+        }
+    }
+}

--- a/src/XtremeIdiots.Portal.Repository.Api.Client.V1/Api/V1/ConnectedPlayersApi.cs
+++ b/src/XtremeIdiots.Portal.Repository.Api.Client.V1/Api/V1/ConnectedPlayersApi.cs
@@ -86,6 +86,8 @@ namespace XtremeIdiots.Portal.Repository.Api.Client.V1
             bool? isActive,
             int skipEntries,
             int takeEntries,
+            string? searchString = null,
+            ConnectedPlayersOrder? order = null,
             CancellationToken cancellationToken = default)
         {
             var request = await CreateRequestAsync("v1/connected-players", Method.Get).ConfigureAwait(false);
@@ -112,6 +114,16 @@ namespace XtremeIdiots.Portal.Repository.Api.Client.V1
 
             request.AddQueryParameter(nameof(skipEntries), skipEntries);
             request.AddQueryParameter(nameof(takeEntries), takeEntries);
+
+            if (!string.IsNullOrWhiteSpace(searchString))
+            {
+                request.AddQueryParameter(nameof(searchString), searchString);
+            }
+
+            if (order.HasValue)
+            {
+                request.AddQueryParameter(nameof(order), order.Value.ToString());
+            }
 
             var response = await ExecuteAsync(request).ConfigureAwait(false);
             return response.ToApiResult<CollectionModel<ConnectedPlayerDto>>();

--- a/src/XtremeIdiots.Portal.Repository.Api.Client.V1/Caching/RepositoryApiCacheDefaults.cs
+++ b/src/XtremeIdiots.Portal.Repository.Api.Client.V1/Caching/RepositoryApiCacheDefaults.cs
@@ -1,0 +1,139 @@
+using System;
+using System.Threading.Tasks;
+
+using MX.Api.Abstractions;
+using MX.Api.Client.Configuration;
+
+using XtremeIdiots.Portal.Repository.Abstractions.Constants.V1;
+using XtremeIdiots.Portal.Repository.Abstractions.Interfaces.V1;
+using XtremeIdiots.Portal.Repository.Abstractions.Models;
+using XtremeIdiots.Portal.Repository.Abstractions.Models.V1.GameServers;
+using XtremeIdiots.Portal.Repository.Abstractions.Models.V1.Maps;
+using XtremeIdiots.Portal.Repository.Abstractions.Models.V1.UserProfiles;
+
+namespace XtremeIdiots.Portal.Repository.Api.Client.V1.Caching
+{
+    /// <summary>
+    /// Default cache policies shipped by the Repository API Client V1 package.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// MX.Api.Client 2.3.76 registers library defaults per typed API client interface via
+    /// <c>AddDefaultCachePolicies&lt;TClient&gt;(...)</c>. Because each sub-API
+    /// (<see cref="IGameServersApi"/>, <see cref="IMapsApi"/>, etc.) is registered as its own
+    /// typed client through <c>AddTypedApiClient&lt;TClient, ...&gt;</c>, defaults must be
+    /// scoped to the same sub-API interface used when the typed client is registered.
+    /// </para>
+    /// <para>
+    /// Policy set:
+    /// <list type="bullet">
+    ///   <item><description>GET single game server → 60 seconds in-memory.</description></item>
+    ///   <item><description>GET game server list → 60 seconds in-memory.</description></item>
+    ///   <item><description>GET map by id and GET map by (game type, name) → 10 minutes in-memory.</description></item>
+    ///   <item><description>GET maps list → 10 minutes in-memory.</description></item>
+    ///   <item><description>All mutating endpoints, user-profile / claims surfaces, and info / health probes → <see cref="CacheBuilder.NotCached{TApi,TResult}"/> to make intent explicit.</description></item>
+    /// </list>
+    /// </para>
+    /// <para>
+    /// MX.Api.Client 2.3.76 does not support parameter-aware dynamic tag expansion on
+    /// client-side cache policies, so no <c>gameserver:{id}</c>-style tags are attached
+    /// here — those live on the server-side <see cref="MX.Caching.Abstractions.IMxCache"/>
+    /// path where the actual identifier is bound at invocation time.
+    /// </para>
+    /// </remarks>
+    public static class RepositoryApiCacheDefaults
+    {
+        /// <summary>Default TTL for game-server reads.</summary>
+        public static readonly TimeSpan GameServerTtl = TimeSpan.FromSeconds(60);
+
+        /// <summary>Default TTL for map reads.</summary>
+        public static readonly TimeSpan MapTtl = TimeSpan.FromMinutes(10);
+
+        /// <summary>Cache defaults for <see cref="IGameServersApi"/>.</summary>
+        public static void ConfigureGameServers(CacheBuilder builder)
+        {
+            ArgumentNullException.ThrowIfNull(builder);
+
+            builder
+                .InMemory<IGameServersApi, Task<ApiResult<GameServerDto>>>(
+                    x => x.GetGameServer(default, default),
+                    GameServerTtl)
+                .InMemory<IGameServersApi, Task<ApiResult<CollectionModel<GameServerDto>>>>(
+                    x => x.GetGameServers(default, default, default, default, default, default, default),
+                    GameServerTtl);
+
+            builder
+                .NotCached<IGameServersApi, Task<ApiResult>>(x => x.CreateGameServer(default!, default))
+                .NotCached<IGameServersApi, Task<ApiResult>>(x => x.CreateGameServers(default!, default))
+                .NotCached<IGameServersApi, Task<ApiResult>>(x => x.UpdateGameServer(default!, default))
+                .NotCached<IGameServersApi, Task<ApiResult>>(x => x.UpdateGameServerOrder(default!, default))
+                .NotCached<IGameServersApi, Task<ApiResult>>(x => x.DeleteGameServer(default, default));
+        }
+
+        /// <summary>Cache defaults for <see cref="IMapsApi"/>.</summary>
+        public static void ConfigureMaps(CacheBuilder builder)
+        {
+            ArgumentNullException.ThrowIfNull(builder);
+
+            builder
+                .InMemory<IMapsApi, Task<ApiResult<MapDto>>>(
+                    x => x.GetMap(Guid.Empty, default),
+                    MapTtl)
+                .InMemory<IMapsApi, Task<ApiResult<MapDto>>>(
+                    x => x.GetMap(GameType.Unknown, string.Empty, default),
+                    MapTtl)
+                .InMemory<IMapsApi, Task<ApiResult<CollectionModel<MapDto>>>>(
+                    x => x.GetMaps(default, default, default, default, default, default, default, default),
+                    MapTtl);
+
+            builder
+                .NotCached<IMapsApi, Task<ApiResult>>(x => x.CreateMap(default!, default))
+                .NotCached<IMapsApi, Task<ApiResult>>(x => x.CreateMaps(default!, default))
+                .NotCached<IMapsApi, Task<ApiResult>>(x => x.UpdateMap(default!, default))
+                .NotCached<IMapsApi, Task<ApiResult>>(x => x.UpdateMaps(default!, default))
+                .NotCached<IMapsApi, Task<ApiResult>>(x => x.DeleteMap(default, default))
+                .NotCached<IMapsApi, Task<ApiResult>>(x => x.RebuildMapPopularity(default))
+                .NotCached<IMapsApi, Task<ApiResult>>(x => x.UpsertMapVote(default!, default))
+                .NotCached<IMapsApi, Task<ApiResult>>(x => x.UpsertMapVotes(default!, default))
+                .NotCached<IMapsApi, Task<ApiResult>>(x => x.UpdateMapImage(default, default!, default))
+                .NotCached<IMapsApi, Task<ApiResult>>(x => x.ClearMapImage(default, default));
+        }
+
+        /// <summary>Cache defaults for <see cref="IUserProfileApi"/>: everything NotCached.</summary>
+        public static void ConfigureUserProfile(CacheBuilder builder)
+        {
+            ArgumentNullException.ThrowIfNull(builder);
+
+            builder
+                .NotCached<IUserProfileApi, Task<ApiResult<UserProfileDto>>>(x => x.GetUserProfile(default, default))
+                .NotCached<IUserProfileApi, Task<ApiResult<UserProfileDto>>>(x => x.GetUserProfileByIdentityId(default!, default))
+                .NotCached<IUserProfileApi, Task<ApiResult<UserProfileDto>>>(x => x.GetUserProfileByXtremeIdiotsId(default!, default))
+                .NotCached<IUserProfileApi, Task<ApiResult<UserProfileDto>>>(x => x.GetUserProfileByDemoAuthKey(default!, default))
+                .NotCached<IUserProfileApi, Task<ApiResult<CollectionModel<UserProfileDto>>>>(
+                    x => x.GetUserProfiles(default, default, default, default, default, default))
+                .NotCached<IUserProfileApi, Task<ApiResult<CollectionModel<PermissionReportEntryDto>>>>(
+                    x => x.GetPermissionsReport(default, default, default))
+                .NotCached<IUserProfileApi, Task<ApiResult>>(x => x.CreateUserProfile(default!, default))
+                .NotCached<IUserProfileApi, Task<ApiResult>>(x => x.CreateUserProfiles(default!, default))
+                .NotCached<IUserProfileApi, Task<ApiResult>>(x => x.UpdateUserProfile(default!, default))
+                .NotCached<IUserProfileApi, Task<ApiResult>>(x => x.UpdateUserProfiles(default!, default))
+                .NotCached<IUserProfileApi, Task<ApiResult>>(x => x.CreateUserProfileClaim(default, default!, default))
+                .NotCached<IUserProfileApi, Task<ApiResult>>(x => x.SetUserProfileClaims(default, default!, default))
+                .NotCached<IUserProfileApi, Task<ApiResult>>(x => x.DeleteUserProfileClaim(default, default, default));
+        }
+
+        /// <summary>Cache defaults for <see cref="IApiInfoApi"/>: never-cache.</summary>
+        public static void ConfigureApiInfo(CacheBuilder builder)
+        {
+            ArgumentNullException.ThrowIfNull(builder);
+            builder.NotCached<IApiInfoApi, Task<ApiResult<ApiInfoDto>>>(x => x.GetApiInfo(default));
+        }
+
+        /// <summary>Cache defaults for <see cref="IApiHealthApi"/>: never-cache.</summary>
+        public static void ConfigureApiHealth(CacheBuilder builder)
+        {
+            ArgumentNullException.ThrowIfNull(builder);
+            builder.NotCached<IApiHealthApi, Task<ApiResult>>(x => x.CheckHealth(default));
+        }
+    }
+}

--- a/src/XtremeIdiots.Portal.Repository.Api.Client.V1/ServiceCollectionExtensions.cs
+++ b/src/XtremeIdiots.Portal.Repository.Api.Client.V1/ServiceCollectionExtensions.cs
@@ -1,6 +1,7 @@
 using Microsoft.Extensions.DependencyInjection;
 using MX.Api.Client.Extensions;
 using XtremeIdiots.Portal.Repository.Abstractions.Interfaces.V1;
+using XtremeIdiots.Portal.Repository.Api.Client.V1.Caching;
 
 namespace XtremeIdiots.Portal.Repository.Api.Client.V1
 {
@@ -16,6 +17,15 @@ namespace XtremeIdiots.Portal.Repository.Api.Client.V1
             this IServiceCollection serviceCollection,
             Action<RepositoryApiOptionsBuilder> configureOptions)
         {
+            // Register library default cache policies per sub-API interface (the same interface
+            // supplied to AddTypedApiClient below). Consumers opt in per client with
+            // UseLibraryDefaults() on their CacheBuilder.
+            serviceCollection.AddDefaultCachePolicies<IGameServersApi>(RepositoryApiCacheDefaults.ConfigureGameServers);
+            serviceCollection.AddDefaultCachePolicies<IMapsApi>(RepositoryApiCacheDefaults.ConfigureMaps);
+            serviceCollection.AddDefaultCachePolicies<IUserProfileApi>(RepositoryApiCacheDefaults.ConfigureUserProfile);
+            serviceCollection.AddDefaultCachePolicies<IApiInfoApi>(RepositoryApiCacheDefaults.ConfigureApiInfo);
+            serviceCollection.AddDefaultCachePolicies<IApiHealthApi>(RepositoryApiCacheDefaults.ConfigureApiHealth);
+
             // Register V1 API implementations using the new typed pattern
             serviceCollection.AddTypedApiClient<IAdminActionsApi, AdminActionsApi, RepositoryApiClientOptions, RepositoryApiOptionsBuilder>(configureOptions);
             serviceCollection.AddTypedApiClient<IBanFileMonitorsApi, BanFileMonitorsApi, RepositoryApiClientOptions, RepositoryApiOptionsBuilder>(configureOptions);

--- a/src/XtremeIdiots.Portal.Repository.Api.Client.V1/XtremeIdiots.Portal.Repository.Api.Client.V1.csproj
+++ b/src/XtremeIdiots.Portal.Repository.Api.Client.V1/XtremeIdiots.Portal.Repository.Api.Client.V1.csproj
@@ -20,8 +20,8 @@
     <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="10.0.10" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.10" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.10" />
-    <PackageReference Include="MX.Api.Client" Version="2.3.67" />
-    <PackageReference Include="MX.Api.Abstractions" Version="2.3.67" />
+    <PackageReference Include="MX.Api.Client" Version="2.3.76" />
+    <PackageReference Include="MX.Api.Abstractions" Version="2.3.76" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageReference Include="RestSharp" Version="114.0.0" />
   </ItemGroup>

--- a/src/XtremeIdiots.Portal.Repository.Api.Client.V2/Caching/RepositoryApiCacheDefaults.cs
+++ b/src/XtremeIdiots.Portal.Repository.Api.Client.V2/Caching/RepositoryApiCacheDefaults.cs
@@ -1,0 +1,37 @@
+using System;
+using System.Threading.Tasks;
+
+using MX.Api.Abstractions;
+using MX.Api.Client.Configuration;
+
+using XtremeIdiots.Portal.Repository.Abstractions.Interfaces.V2;
+using XtremeIdiots.Portal.Repository.Abstractions.Models;
+
+namespace XtremeIdiots.Portal.Repository.Api.Client.V2.Caching
+{
+    /// <summary>
+    /// Default cache policies shipped by the Repository API Client V2 package.
+    /// </summary>
+    /// <remarks>
+    /// V2 currently exposes only <see cref="IApiInfoApi"/> and <see cref="IApiHealthApi"/>.
+    /// Both must be treated as never-cache: <c>/info</c> drives deploy version verification and
+    /// <c>/health/*</c> must always return live status. There is no V2 resource surface to
+    /// register positive cache policies against.
+    /// </remarks>
+    public static class RepositoryApiCacheDefaults
+    {
+        /// <summary>Cache defaults for V2 <see cref="IApiInfoApi"/>: never-cache.</summary>
+        public static void ConfigureApiInfo(CacheBuilder builder)
+        {
+            ArgumentNullException.ThrowIfNull(builder);
+            builder.NotCached<IApiInfoApi, Task<ApiResult<ApiInfoDto>>>(x => x.GetApiInfo(default));
+        }
+
+        /// <summary>Cache defaults for V2 <see cref="IApiHealthApi"/>: never-cache.</summary>
+        public static void ConfigureApiHealth(CacheBuilder builder)
+        {
+            ArgumentNullException.ThrowIfNull(builder);
+            builder.NotCached<IApiHealthApi, Task<ApiResult>>(x => x.CheckHealth(default));
+        }
+    }
+}

--- a/src/XtremeIdiots.Portal.Repository.Api.Client.V2/ServiceCollectionExtensions.cs
+++ b/src/XtremeIdiots.Portal.Repository.Api.Client.V2/ServiceCollectionExtensions.cs
@@ -1,6 +1,7 @@
 using Microsoft.Extensions.DependencyInjection;
 using MX.Api.Client.Extensions;
 using XtremeIdiots.Portal.Repository.Abstractions.Interfaces.V2;
+using XtremeIdiots.Portal.Repository.Api.Client.V2.Caching;
 
 namespace XtremeIdiots.Portal.Repository.Api.Client.V2
 {
@@ -16,6 +17,11 @@ namespace XtremeIdiots.Portal.Repository.Api.Client.V2
             this IServiceCollection serviceCollection,
             Action<RepositoryApiOptionsBuilder> configureOptions)
         {
+            // Register library default cache policies per sub-API interface. Consumers opt in
+            // per client with UseLibraryDefaults() on their CacheBuilder.
+            serviceCollection.AddDefaultCachePolicies<IApiInfoApi>(RepositoryApiCacheDefaults.ConfigureApiInfo);
+            serviceCollection.AddDefaultCachePolicies<IApiHealthApi>(RepositoryApiCacheDefaults.ConfigureApiHealth);
+
             // Register API info endpoint
             serviceCollection.AddTypedApiClient<IApiInfoApi, ApiInfoApi, RepositoryApiClientOptions, RepositoryApiOptionsBuilder>(configureOptions);
 

--- a/src/XtremeIdiots.Portal.Repository.Api.Client.V2/XtremeIdiots.Portal.Repository.Api.Client.V2.csproj
+++ b/src/XtremeIdiots.Portal.Repository.Api.Client.V2/XtremeIdiots.Portal.Repository.Api.Client.V2.csproj
@@ -21,8 +21,8 @@
     <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="10.0.10" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.10" />
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.10" />
-    <PackageReference Include="MX.Api.Client" Version="2.3.67" />
-    <PackageReference Include="MX.Api.Abstractions" Version="2.3.67" />
+    <PackageReference Include="MX.Api.Client" Version="2.3.76" />
+    <PackageReference Include="MX.Api.Abstractions" Version="2.3.76" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageReference Include="RestSharp" Version="114.0.0" />
   </ItemGroup>

--- a/src/XtremeIdiots.Portal.Repository.Api.Tests.V1/Controllers/V1/ConnectedPlayersControllerTests.cs
+++ b/src/XtremeIdiots.Portal.Repository.Api.Tests.V1/Controllers/V1/ConnectedPlayersControllerTests.cs
@@ -904,4 +904,152 @@ public class ConnectedPlayersControllerTests
         var hash = SHA256.HashData(bytes);
         return Convert.ToHexString(hash);
     }
+
+    // ---- GetConnectedPlayers search + sort + pagination ----
+
+    private static async Task<PortalDbContext> SeedFourConnectedPlayersAsync()
+    {
+        var ctx = DbContextHelper.CreateInMemoryContext();
+
+        // Four players so we can prove filter + sort semantics.
+        var p1 = new Player { PlayerId = Guid.NewGuid(), GameType = (int)GameType.CallOfDuty4, Username = "AlphaOne", FirstSeen = DateTime.UtcNow, LastSeen = DateTime.UtcNow };
+        var p2 = new Player { PlayerId = Guid.NewGuid(), GameType = (int)GameType.CallOfDuty4, Username = "BravoTwo", FirstSeen = DateTime.UtcNow, LastSeen = DateTime.UtcNow };
+        var p3 = new Player { PlayerId = Guid.NewGuid(), GameType = (int)GameType.CallOfDuty5, Username = "Charlie", FirstSeen = DateTime.UtcNow, LastSeen = DateTime.UtcNow };
+        var p4 = new Player { PlayerId = Guid.NewGuid(), GameType = (int)GameType.CallOfDuty5, Username = "Delta", FirstSeen = DateTime.UtcNow, LastSeen = DateTime.UtcNow };
+        ctx.Players.AddRange(p1, p2, p3, p4);
+
+        var up1 = new UserProfile { UserProfileId = Guid.NewGuid(), DisplayName = "u1" };
+        var up2 = new UserProfile { UserProfileId = Guid.NewGuid(), DisplayName = "u2" };
+        var up3 = new UserProfile { UserProfileId = Guid.NewGuid(), DisplayName = "u3" };
+        var up4 = new UserProfile { UserProfileId = Guid.NewGuid(), DisplayName = "u4" };
+        ctx.UserProfiles.AddRange(up1, up2, up3, up4);
+
+        var t0 = DateTime.UtcNow.AddHours(-4);
+        ctx.ConnectedPlayerProfiles.AddRange(
+            new ConnectedPlayerProfile { ConnectedPlayerProfileId = Guid.NewGuid(), PlayerId = p1.PlayerId, UserProfileId = up1.UserProfileId, LinkMethod = ConnectedPlayerLinkMethod.TrustedWebsite.ToString(), LinkedAtUtc = t0.AddHours(1), IsActive = true },
+            new ConnectedPlayerProfile { ConnectedPlayerProfileId = Guid.NewGuid(), PlayerId = p2.PlayerId, UserProfileId = up2.UserProfileId, LinkMethod = ConnectedPlayerLinkMethod.ActivationCode.ToString(), LinkedAtUtc = t0.AddHours(2), IsActive = true },
+            new ConnectedPlayerProfile { ConnectedPlayerProfileId = Guid.NewGuid(), PlayerId = p3.PlayerId, UserProfileId = up3.UserProfileId, LinkMethod = ConnectedPlayerLinkMethod.ActivationCode.ToString(), LinkedAtUtc = t0.AddHours(3), IsActive = false, UnlinkedAtUtc = t0.AddHours(3.5) },
+            new ConnectedPlayerProfile { ConnectedPlayerProfileId = Guid.NewGuid(), PlayerId = p4.PlayerId, UserProfileId = up4.UserProfileId, LinkMethod = ConnectedPlayerLinkMethod.TrustedWebsite.ToString(), LinkedAtUtc = t0.AddHours(4), IsActive = true }
+        );
+
+        await ctx.SaveChangesAsync();
+        return ctx;
+    }
+
+    [Fact]
+    public async Task GetConnectedPlayers_DefaultOrder_IsLinkedAtUtcDescending()
+    {
+        using var context = await SeedFourConnectedPlayersAsync();
+        var api = (IConnectedPlayersApi)CreateController(context);
+
+        var result = await api.GetConnectedPlayers(null, null, null, isActive: null, skipEntries: 0, takeEntries: 20);
+
+        Assert.Equal(HttpStatusCode.OK, result.StatusCode);
+        var items = result.Result!.Data!.Items!.ToList();
+        Assert.Equal(4, items.Count);
+        for (var i = 1; i < items.Count; i++)
+        {
+            Assert.True(items[i - 1].LinkedAtUtc >= items[i].LinkedAtUtc);
+        }
+    }
+
+    [Fact]
+    public async Task GetConnectedPlayers_TotalCount_IgnoresFilters_FilteredCountRespectsThem()
+    {
+        using var context = await SeedFourConnectedPlayersAsync();
+        var api = (IConnectedPlayersApi)CreateController(context);
+
+        var result = await api.GetConnectedPlayers(null, null, GameType.CallOfDuty5, isActive: null, skipEntries: 0, takeEntries: 20);
+
+        Assert.Equal(HttpStatusCode.OK, result.StatusCode);
+        var pagination = result.Result!.Pagination!;
+        Assert.Equal(4, pagination.TotalCount);
+        Assert.Equal(2, pagination.FilteredCount);
+    }
+
+    [Fact]
+    public async Task GetConnectedPlayers_SearchUsernameSubstring_MatchesCaseInsensitive()
+    {
+        using var context = await SeedFourConnectedPlayersAsync();
+        var api = (IConnectedPlayersApi)CreateController(context);
+
+        var result = await api.GetConnectedPlayers(null, null, null, isActive: null, skipEntries: 0, takeEntries: 20, searchString: "alpha");
+
+        Assert.Equal(HttpStatusCode.OK, result.StatusCode);
+        var items = result.Result!.Data!.Items!.ToList();
+        Assert.Single(items);
+        Assert.Equal("AlphaOne", items[0].Username);
+    }
+
+    [Fact]
+    public async Task GetConnectedPlayers_SearchLinkMethod_MatchesEnumString()
+    {
+        using var context = await SeedFourConnectedPlayersAsync();
+        var api = (IConnectedPlayersApi)CreateController(context);
+
+        var result = await api.GetConnectedPlayers(null, null, null, isActive: null, skipEntries: 0, takeEntries: 20, searchString: "activationcode");
+
+        Assert.Equal(HttpStatusCode.OK, result.StatusCode);
+        var items = result.Result!.Data!.Items!.ToList();
+        Assert.Equal(2, items.Count);
+        Assert.All(items, i => Assert.Equal(ConnectedPlayerLinkMethod.ActivationCode, i.LinkMethod));
+    }
+
+    [Fact]
+    public async Task GetConnectedPlayers_SearchGameTypeString_Matches()
+    {
+        using var context = await SeedFourConnectedPlayersAsync();
+        var api = (IConnectedPlayersApi)CreateController(context);
+
+        var result = await api.GetConnectedPlayers(null, null, null, isActive: null, skipEntries: 0, takeEntries: 20, searchString: "CallOfDuty4");
+
+        Assert.Equal(HttpStatusCode.OK, result.StatusCode);
+        var items = result.Result!.Data!.Items!.ToList();
+        Assert.Equal(2, items.Count);
+        Assert.All(items, i => Assert.Equal(GameType.CallOfDuty4, i.GameType));
+    }
+
+    [Fact]
+    public async Task GetConnectedPlayers_OrderUsernameAsc_SortsAscending()
+    {
+        using var context = await SeedFourConnectedPlayersAsync();
+        var api = (IConnectedPlayersApi)CreateController(context);
+
+        var result = await api.GetConnectedPlayers(null, null, null, isActive: null, skipEntries: 0, takeEntries: 20, order: ConnectedPlayersOrder.UsernameAsc);
+
+        Assert.Equal(HttpStatusCode.OK, result.StatusCode);
+        var names = result.Result!.Data!.Items!.Select(i => i.Username).ToList();
+        Assert.Equal(new[] { "AlphaOne", "BravoTwo", "Charlie", "Delta" }, names);
+    }
+
+    [Fact]
+    public async Task GetConnectedPlayers_OrderLinkedAtAsc_SortsOldestFirst()
+    {
+        using var context = await SeedFourConnectedPlayersAsync();
+        var api = (IConnectedPlayersApi)CreateController(context);
+
+        var result = await api.GetConnectedPlayers(null, null, null, isActive: null, skipEntries: 0, takeEntries: 20, order: ConnectedPlayersOrder.LinkedAtUtcAsc);
+
+        Assert.Equal(HttpStatusCode.OK, result.StatusCode);
+        var items = result.Result!.Data!.Items!.ToList();
+        for (var i = 1; i < items.Count; i++)
+        {
+            Assert.True(items[i - 1].LinkedAtUtc <= items[i].LinkedAtUtc);
+        }
+    }
+
+    [Fact]
+    public async Task GetConnectedPlayers_ClampsSkipAndTake()
+    {
+        using var context = await SeedFourConnectedPlayersAsync();
+        var api = (IConnectedPlayersApi)CreateController(context);
+
+        // takeEntries=0 → clamped up to 20 (all rows returned when there are only 4).
+        var result = await api.GetConnectedPlayers(null, null, null, isActive: null, skipEntries: -5, takeEntries: 0);
+
+        Assert.Equal(HttpStatusCode.OK, result.StatusCode);
+        var items = result.Result!.Data!.Items!.ToList();
+        Assert.Equal(4, items.Count);
+    }
 }
+

--- a/src/XtremeIdiots.Portal.Repository.Api.Tests.V1/Controllers/V1/GameServerConfigurationsControllerTests.cs
+++ b/src/XtremeIdiots.Portal.Repository.Api.Tests.V1/Controllers/V1/GameServerConfigurationsControllerTests.cs
@@ -5,6 +5,8 @@ using XtremeIdiots.Portal.Repository.Abstractions.Interfaces.V1;
 using XtremeIdiots.Portal.Repository.Abstractions.Models.V1.Configurations;
 using XtremeIdiots.Portal.Repository.Api.Tests.V1.TestHelpers;
 using XtremeIdiots.Portal.Repository.DataLib;
+using XtremeIdiots.Portal.Repository.Api.V1.Services;
+using XtremeIdiots.Portal.Repository.Api.V1.Services.Caching;
 using XtremeIdiots.Portal.RepositoryWebApi.Controllers.V1;
 
 namespace XtremeIdiots.Portal.Repository.Api.Tests.V1.Controllers.V1;
@@ -13,7 +15,8 @@ public class GameServerConfigurationsControllerTests
 {
     private GameServerConfigurationsController CreateController(PortalDbContext context)
     {
-        return new GameServerConfigurationsController(context);
+        var readService = new ConfigurationReadService(context);
+        return new GameServerConfigurationsController(context, readService, new NoOpRepositoryCacheInvalidator());
     }
 
     private GameServer CreateTestGameServer(Guid? gameServerId = null)

--- a/src/XtremeIdiots.Portal.Repository.Api.Tests.V1/Controllers/V1/GameServersControllerTests.cs
+++ b/src/XtremeIdiots.Portal.Repository.Api.Tests.V1/Controllers/V1/GameServersControllerTests.cs
@@ -8,6 +8,8 @@ using XtremeIdiots.Portal.Repository.Abstractions.Interfaces.V1;
 using XtremeIdiots.Portal.Repository.Abstractions.Models.V1.GameServers;
 using XtremeIdiots.Portal.Repository.Api.Tests.V1.TestHelpers;
 using XtremeIdiots.Portal.Repository.DataLib;
+using XtremeIdiots.Portal.Repository.Api.V1.Services;
+using XtremeIdiots.Portal.Repository.Api.V1.Services.Caching;
 using XtremeIdiots.Portal.RepositoryWebApi.Controllers.V1;
 
 namespace XtremeIdiots.Portal.Repository.Api.Tests.V1.Controllers.V1;
@@ -16,7 +18,8 @@ public class GameServersControllerTests
 {
     private GameServersController CreateController(PortalDbContext context)
     {
-        return new GameServersController(context);
+        var readService = new GameServerReadService(context);
+        return new GameServersController(context, readService, new NoOpRepositoryCacheInvalidator());
     }
 
     [Fact]

--- a/src/XtremeIdiots.Portal.Repository.Api.Tests.V1/Controllers/V1/GlobalConfigurationsControllerTests.cs
+++ b/src/XtremeIdiots.Portal.Repository.Api.Tests.V1/Controllers/V1/GlobalConfigurationsControllerTests.cs
@@ -4,6 +4,8 @@ using XtremeIdiots.Portal.Repository.Abstractions.Interfaces.V1;
 using XtremeIdiots.Portal.Repository.Abstractions.Models.V1.Configurations;
 using XtremeIdiots.Portal.Repository.Api.Tests.V1.TestHelpers;
 using XtremeIdiots.Portal.Repository.DataLib;
+using XtremeIdiots.Portal.Repository.Api.V1.Services;
+using XtremeIdiots.Portal.Repository.Api.V1.Services.Caching;
 using XtremeIdiots.Portal.RepositoryWebApi.Controllers.V1;
 
 namespace XtremeIdiots.Portal.Repository.Api.Tests.V1.Controllers.V1;
@@ -12,7 +14,8 @@ public class GlobalConfigurationsControllerTests
 {
     private GlobalConfigurationsController CreateController(PortalDbContext context)
     {
-        return new GlobalConfigurationsController(context);
+        var readService = new ConfigurationReadService(context);
+        return new GlobalConfigurationsController(context, readService, new NoOpRepositoryCacheInvalidator());
     }
 
     [Fact]

--- a/src/XtremeIdiots.Portal.Repository.Api.Tests.V1/Extensions/NoStoreCacheAttributeTests.cs
+++ b/src/XtremeIdiots.Portal.Repository.Api.Tests.V1/Extensions/NoStoreCacheAttributeTests.cs
@@ -1,0 +1,65 @@
+using System.Collections.Generic;
+
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Abstractions;
+using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.AspNetCore.Routing;
+
+using XtremeIdiots.Portal.Repository.Api.V1.Extensions;
+
+using Xunit;
+
+namespace XtremeIdiots.Portal.Repository.Api.Tests.V1.Extensions
+{
+    /// <summary>
+    /// Verifies the <see cref="NoStoreCacheAttribute"/> stamps deterministic never-cache headers
+    /// on responses. This protects deploy version verification (<c>/v1.0/info</c>) and the
+    /// health probes from being served stale by any intermediary.
+    /// </summary>
+    public class NoStoreCacheAttributeTests
+    {
+        [Fact]
+        public void OnActionExecuted_SetsCacheControlNoStore()
+        {
+            var (attribute, context) = CreateExecutedContext();
+
+            attribute.OnActionExecuted(context);
+
+            var headers = context.HttpContext.Response.Headers;
+            Assert.Equal("no-store, no-cache, must-revalidate, max-age=0", headers.CacheControl.ToString());
+            Assert.Equal("no-cache", headers.Pragma.ToString());
+            Assert.Equal("0", headers.Expires.ToString());
+        }
+
+        [Fact]
+        public void OnActionExecuted_OverwritesExistingCacheControl()
+        {
+            var (attribute, context) = CreateExecutedContext();
+            context.HttpContext.Response.Headers.CacheControl = "public, max-age=300";
+
+            attribute.OnActionExecuted(context);
+
+            Assert.Equal("no-store, no-cache, must-revalidate, max-age=0",
+                context.HttpContext.Response.Headers.CacheControl.ToString());
+        }
+
+        [Fact]
+        public void AppliedToInfoAndHealthControllers()
+        {
+            var infoType = typeof(RepositoryWebApi.Controllers.V1.ApiInfoController);
+            var healthType = typeof(RepositoryWebApi.Controllers.V1.HealthController);
+
+            Assert.NotEmpty(infoType.GetCustomAttributes(typeof(NoStoreCacheAttribute), inherit: true));
+            Assert.NotEmpty(healthType.GetCustomAttributes(typeof(NoStoreCacheAttribute), inherit: true));
+        }
+
+        private static (NoStoreCacheAttribute attribute, ActionExecutedContext context) CreateExecutedContext()
+        {
+            var httpContext = new DefaultHttpContext();
+            var actionContext = new ActionContext(httpContext, new RouteData(), new ActionDescriptor());
+            var context = new ActionExecutedContext(actionContext, new List<IFilterMetadata>(), controller: new object());
+            return (new NoStoreCacheAttribute(), context);
+        }
+    }
+}

--- a/src/XtremeIdiots.Portal.Repository.Api.Tests.V1/Services/Caching/CachingReadServicesTests.cs
+++ b/src/XtremeIdiots.Portal.Repository.Api.Tests.V1/Services/Caching/CachingReadServicesTests.cs
@@ -1,0 +1,309 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+using System.Net;
+
+using MX.Api.Abstractions;
+using MX.Caching.Testing;
+
+using XtremeIdiots.Portal.Repository.Abstractions.Models.V1.Configurations;
+using XtremeIdiots.Portal.Repository.Abstractions.Models.V1.Dashboard;
+using XtremeIdiots.Portal.Repository.Abstractions.Models.V1.GameServers;
+using XtremeIdiots.Portal.Repository.Api.V1.Services;
+using XtremeIdiots.Portal.Repository.Api.V1.Services.Caching;
+using XtremeIdiots.Portal.Repository.Api.V1.Validation;
+
+using Xunit;
+
+namespace XtremeIdiots.Portal.Repository.Api.Tests.V1.Services.Caching
+{
+    /// <summary>
+    /// Cache-aside behavior tests for the read-service decorators. Uses the
+    /// <see cref="FakeMxCache"/> from MX.Caching.Testing to prove repeated-hit and precise
+    /// tag-eviction semantics without exercising Table Storage.
+    /// </summary>
+    public class CachingReadServicesTests
+    {
+        private static RepositoryCacheMetrics CreateMetrics() => new();
+
+        private static ApiResult<T> Ok<T>(T value) => new(HttpStatusCode.OK, new ApiResponse<T>(value));
+
+        // --- GameServer ---
+
+        private sealed class CountingGameServerReadService : IGameServerReadService
+        {
+            public int CallCount { get; private set; }
+            public Func<Guid, ApiResult<GameServerDto>>? Factory { get; set; }
+
+            public Task<ApiResult<GameServerDto>> GetGameServerAsync(Guid gameServerId, CancellationToken cancellationToken)
+            {
+                CallCount++;
+                var result = Factory?.Invoke(gameServerId) ?? Ok(new GameServerDto());
+                return Task.FromResult(result);
+            }
+        }
+
+        [Fact]
+        public async Task CachingGameServerReadService_ReturnsCachedValue_OnRepeatedHit()
+        {
+            var inner = new CountingGameServerReadService();
+            var cache = new FakeMxCache();
+            var subject = new CachingGameServerReadService(inner, cache, CreateMetrics());
+            var id = Guid.NewGuid();
+
+            var first = await subject.GetGameServerAsync(id, CancellationToken.None);
+            var second = await subject.GetGameServerAsync(id, CancellationToken.None);
+
+            Assert.Equal(1, inner.CallCount);
+            Assert.True(first.IsSuccess);
+            Assert.True(second.IsSuccess);
+        }
+
+        [Fact]
+        public async Task CachingGameServerReadService_DoesNotCache_UnsuccessfulResult()
+        {
+            var inner = new CountingGameServerReadService { Factory = _ => new ApiResult<GameServerDto>(HttpStatusCode.NotFound) };
+            var cache = new FakeMxCache();
+            var subject = new CachingGameServerReadService(inner, cache, CreateMetrics());
+            var id = Guid.NewGuid();
+
+            _ = await subject.GetGameServerAsync(id, CancellationToken.None);
+            _ = await subject.GetGameServerAsync(id, CancellationToken.None);
+
+            Assert.Equal(2, inner.CallCount);
+        }
+
+        [Fact]
+        public async Task InvalidateGameServer_EvictsCachedEntry_ForThatId()
+        {
+            var inner = new CountingGameServerReadService();
+            var cache = new FakeMxCache();
+            var metrics = CreateMetrics();
+            var subject = new CachingGameServerReadService(inner, cache, metrics);
+            var invalidator = new RepositoryCacheInvalidator(cache, metrics);
+            var id = Guid.NewGuid();
+
+            _ = await subject.GetGameServerAsync(id, CancellationToken.None);
+            await invalidator.InvalidateGameServerAsync(id, CancellationToken.None);
+            _ = await subject.GetGameServerAsync(id, CancellationToken.None);
+
+            Assert.Equal(2, inner.CallCount);
+        }
+
+        [Fact]
+        public async Task InvalidateGameServer_DoesNotEvict_OtherIds()
+        {
+            var inner = new CountingGameServerReadService();
+            var cache = new FakeMxCache();
+            var metrics = CreateMetrics();
+            var subject = new CachingGameServerReadService(inner, cache, metrics);
+            var invalidator = new RepositoryCacheInvalidator(cache, metrics);
+            var idA = Guid.NewGuid();
+            var idB = Guid.NewGuid();
+
+            _ = await subject.GetGameServerAsync(idA, CancellationToken.None);
+            _ = await subject.GetGameServerAsync(idB, CancellationToken.None);
+            await invalidator.InvalidateGameServerAsync(idA, CancellationToken.None);
+            _ = await subject.GetGameServerAsync(idB, CancellationToken.None); // still cached
+
+            Assert.Equal(2, inner.CallCount);
+        }
+
+        // --- Dashboard ---
+
+        private sealed class CountingDashboardService : IDashboardService
+        {
+            public int SummaryCalls { get; private set; }
+            public int LeaderboardCalls { get; private set; }
+            public int ModerationCalls { get; private set; }
+            public int UtilizationCalls { get; private set; }
+
+            public Task<ApiResult<DashboardSummaryDto>> GetDashboardSummaryAsync(CancellationToken cancellationToken)
+            { SummaryCalls++; return Task.FromResult(Ok(new DashboardSummaryDto())); }
+
+            public Task<ApiResult<CollectionModel<AdminLeaderboardEntryDto>>> GetAdminLeaderboardAsync(int days, CancellationToken cancellationToken)
+            { LeaderboardCalls++; return Task.FromResult(Ok(new CollectionModel<AdminLeaderboardEntryDto>())); }
+
+            public Task<ApiResult<CollectionModel<ModerationTrendDataPointDto>>> GetModerationTrendAsync(int days, CancellationToken cancellationToken)
+            { ModerationCalls++; return Task.FromResult(Ok(new CollectionModel<ModerationTrendDataPointDto>())); }
+
+            public Task<ApiResult<ServerUtilizationCollectionDto>> GetServerUtilizationAsync(CancellationToken cancellationToken)
+            { UtilizationCalls++; return Task.FromResult(Ok(new ServerUtilizationCollectionDto())); }
+        }
+
+        [Fact]
+        public async Task CachingDashboardService_CachesEachAggregation_PerMetricAndWindow()
+        {
+            var inner = new CountingDashboardService();
+            var cache = new FakeMxCache();
+            var subject = new CachingDashboardService(inner, cache, CreateMetrics());
+
+            _ = await subject.GetDashboardSummaryAsync(CancellationToken.None);
+            _ = await subject.GetDashboardSummaryAsync(CancellationToken.None);
+            _ = await subject.GetAdminLeaderboardAsync(30, CancellationToken.None);
+            _ = await subject.GetAdminLeaderboardAsync(30, CancellationToken.None);
+            _ = await subject.GetModerationTrendAsync(30, CancellationToken.None);
+            _ = await subject.GetModerationTrendAsync(30, CancellationToken.None);
+            _ = await subject.GetServerUtilizationAsync(CancellationToken.None);
+            _ = await subject.GetServerUtilizationAsync(CancellationToken.None);
+
+            Assert.Equal(1, inner.SummaryCalls);
+            Assert.Equal(1, inner.LeaderboardCalls);
+            Assert.Equal(1, inner.ModerationCalls);
+            Assert.Equal(1, inner.UtilizationCalls);
+        }
+
+        [Fact]
+        public async Task CachingDashboardService_DifferentWindows_KeyIndependently()
+        {
+            var inner = new CountingDashboardService();
+            var cache = new FakeMxCache();
+            var subject = new CachingDashboardService(inner, cache, CreateMetrics());
+
+            _ = await subject.GetAdminLeaderboardAsync(30, CancellationToken.None);
+            _ = await subject.GetAdminLeaderboardAsync(7, CancellationToken.None);
+            _ = await subject.GetAdminLeaderboardAsync(30, CancellationToken.None); // hit
+            _ = await subject.GetAdminLeaderboardAsync(7, CancellationToken.None);  // hit
+
+            Assert.Equal(2, inner.LeaderboardCalls);
+        }
+
+        [Fact]
+        public async Task InvalidateDashboard_EvictsAllAggregations()
+        {
+            var inner = new CountingDashboardService();
+            var cache = new FakeMxCache();
+            var metrics = CreateMetrics();
+            var subject = new CachingDashboardService(inner, cache, metrics);
+            var invalidator = new RepositoryCacheInvalidator(cache, metrics);
+
+            _ = await subject.GetDashboardSummaryAsync(CancellationToken.None);
+            _ = await subject.GetAdminLeaderboardAsync(30, CancellationToken.None);
+
+            await invalidator.InvalidateDashboardAsync(CancellationToken.None);
+
+            _ = await subject.GetDashboardSummaryAsync(CancellationToken.None);
+            _ = await subject.GetAdminLeaderboardAsync(30, CancellationToken.None);
+
+            Assert.Equal(2, inner.SummaryCalls);
+            Assert.Equal(2, inner.LeaderboardCalls);
+        }
+
+        // --- Configurations ---
+
+        private sealed class CountingConfigurationReadService : IConfigurationReadService
+        {
+            public int ServerCalls { get; private set; }
+            public int GlobalCalls { get; private set; }
+
+            public Task<ApiResult<ConfigurationDto>> GetServerConfigurationAsync(Guid gameServerId, string ns, CancellationToken cancellationToken)
+            { ServerCalls++; return Task.FromResult(Ok(new ConfigurationDto())); }
+
+            public Task<ApiResult<ConfigurationDto>> GetGlobalConfigurationAsync(string ns, CancellationToken cancellationToken)
+            { GlobalCalls++; return Task.FromResult(Ok(new ConfigurationDto())); }
+        }
+
+        [Fact]
+        public async Task CachingConfigurationReadService_CachesServer_ByIdAndNamespace()
+        {
+            var inner = new CountingConfigurationReadService();
+            var cache = new FakeMxCache();
+            var subject = new CachingConfigurationReadService(inner, cache, CreateMetrics());
+            var id = Guid.NewGuid();
+
+            _ = await subject.GetServerConfigurationAsync(id, "ftp", CancellationToken.None);
+            _ = await subject.GetServerConfigurationAsync(id, "ftp", CancellationToken.None);
+            _ = await subject.GetServerConfigurationAsync(id, "rcon", CancellationToken.None);
+
+            Assert.Equal(2, inner.ServerCalls);
+        }
+
+        [Fact]
+        public async Task InvalidateServerSettings_EvictsPreciseServerNamespace_ButNotOthers()
+        {
+            var inner = new CountingConfigurationReadService();
+            var cache = new FakeMxCache();
+            var metrics = CreateMetrics();
+            var subject = new CachingConfigurationReadService(inner, cache, metrics);
+            var invalidator = new RepositoryCacheInvalidator(cache, metrics);
+            var id = Guid.NewGuid();
+
+            _ = await subject.GetServerConfigurationAsync(id, "ftp", CancellationToken.None);
+            _ = await subject.GetServerConfigurationAsync(id, "rcon", CancellationToken.None);
+
+            await invalidator.InvalidateServerSettingsAsync(id, "ftp", CancellationToken.None);
+
+            _ = await subject.GetServerConfigurationAsync(id, "ftp", CancellationToken.None); // miss
+            _ = await subject.GetServerConfigurationAsync(id, "rcon", CancellationToken.None); // still hit
+
+            Assert.Equal(3, inner.ServerCalls);
+        }
+
+        [Fact]
+        public async Task InvalidateGlobalNamespace_EvictsGlobalAndAllServerEntries_ForThatNamespace()
+        {
+            var inner = new CountingConfigurationReadService();
+            var cache = new FakeMxCache();
+            var metrics = CreateMetrics();
+            var subject = new CachingConfigurationReadService(inner, cache, metrics);
+            var invalidator = new RepositoryCacheInvalidator(cache, metrics);
+
+            var idA = Guid.NewGuid();
+            var idB = Guid.NewGuid();
+
+            _ = await subject.GetServerConfigurationAsync(idA, "agent", CancellationToken.None);
+            _ = await subject.GetServerConfigurationAsync(idB, "agent", CancellationToken.None);
+            _ = await subject.GetGlobalConfigurationAsync("agent", CancellationToken.None);
+            _ = await subject.GetServerConfigurationAsync(idA, "banfiles", CancellationToken.None);
+
+            await invalidator.InvalidateGlobalNamespaceAsync("agent", CancellationToken.None);
+
+            _ = await subject.GetServerConfigurationAsync(idA, "agent", CancellationToken.None); // miss
+            _ = await subject.GetServerConfigurationAsync(idB, "agent", CancellationToken.None); // miss
+            _ = await subject.GetGlobalConfigurationAsync("agent", CancellationToken.None);      // miss
+            _ = await subject.GetServerConfigurationAsync(idA, "banfiles", CancellationToken.None); // still hit
+
+            Assert.Equal(5, inner.ServerCalls);
+            Assert.Equal(2, inner.GlobalCalls);
+        }
+
+        [Fact]
+        public async Task CachingConfigurationReadService_NormalizesLegacyAlias_SoInvalidationAffectsAliasEntries()
+        {
+            // The legacy alias "serverList" is normalized by the write-path invalidator to
+            // the canonical namespace before it removes tags. If the caching decorator did
+            // not also normalize, an alias-scoped entry would linger until TTL. This test
+            // proves the decorator normalizes so a subsequent invalidation of the canonical
+            // namespace evicts entries written via either name.
+            var inner = new CountingConfigurationReadService();
+            var cache = new FakeMxCache();
+            var metrics = CreateMetrics();
+            var subject = new CachingConfigurationReadService(inner, cache, metrics);
+            var invalidator = new RepositoryCacheInvalidator(cache, metrics);
+            var id = Guid.NewGuid();
+
+            var canonical = NamespaceSchemaValidationRegistry.NormalizeNamespace("serverList");
+
+            // Sanity: alias must differ from canonical for the test to be meaningful.
+            Assert.NotEqual("serverList", canonical);
+
+            _ = await subject.GetGlobalConfigurationAsync("serverList", CancellationToken.None); // miss, cached under canonical
+            _ = await subject.GetServerConfigurationAsync(id, "serverList", CancellationToken.None); // miss, cached under canonical
+            _ = await subject.GetGlobalConfigurationAsync(canonical, CancellationToken.None); // hit
+            _ = await subject.GetServerConfigurationAsync(id, canonical, CancellationToken.None); // hit
+
+            Assert.Equal(1, inner.GlobalCalls);
+            Assert.Equal(1, inner.ServerCalls);
+
+            await invalidator.InvalidateGlobalNamespaceAsync(canonical, CancellationToken.None);
+
+            _ = await subject.GetGlobalConfigurationAsync("serverList", CancellationToken.None); // miss again
+            _ = await subject.GetServerConfigurationAsync(id, "serverList", CancellationToken.None); // miss again
+
+            Assert.Equal(2, inner.GlobalCalls);
+            Assert.Equal(2, inner.ServerCalls);
+        }
+    }
+}

--- a/src/XtremeIdiots.Portal.Repository.Api.Tests.V1/Services/Caching/CachingReadServicesTests.cs
+++ b/src/XtremeIdiots.Portal.Repository.Api.Tests.V1/Services/Caching/CachingReadServicesTests.cs
@@ -305,5 +305,39 @@ namespace XtremeIdiots.Portal.Repository.Api.Tests.V1.Services.Caching
             Assert.Equal(2, inner.GlobalCalls);
             Assert.Equal(2, inner.ServerCalls);
         }
+
+        [Fact]
+        public async Task RepositoryCacheInvalidator_NormalizesLegacyAlias_SoAliasWritesEvictCanonicalTaggedReads()
+        {
+            // Symmetric to the previous test but from the opposite direction: a write path that
+            // uses the legacy alias must still evict the canonical-tagged cache entries produced
+            // by the read decorator, otherwise stale entries linger until TTL.
+            var inner = new CountingConfigurationReadService();
+            var cache = new FakeMxCache();
+            var metrics = CreateMetrics();
+            var subject = new CachingConfigurationReadService(inner, cache, metrics);
+            var invalidator = new RepositoryCacheInvalidator(cache, metrics);
+            var id = Guid.NewGuid();
+
+            var canonical = NamespaceSchemaValidationRegistry.NormalizeNamespace("serverList");
+            Assert.NotEqual("serverList", canonical);
+
+            _ = await subject.GetServerConfigurationAsync(id, canonical, CancellationToken.None); // miss (canonical tag)
+            _ = await subject.GetGlobalConfigurationAsync(canonical, CancellationToken.None); // miss (canonical tag)
+
+            Assert.Equal(1, inner.ServerCalls);
+            Assert.Equal(1, inner.GlobalCalls);
+
+            // Invalidate via the alias — must be normalized inside the invalidator to hit the
+            // canonical tag used by the reads above.
+            await invalidator.InvalidateServerSettingsAsync(id, "serverList", CancellationToken.None);
+            await invalidator.InvalidateGlobalNamespaceAsync("serverList", CancellationToken.None);
+
+            _ = await subject.GetServerConfigurationAsync(id, canonical, CancellationToken.None); // miss again
+            _ = await subject.GetGlobalConfigurationAsync(canonical, CancellationToken.None); // miss again
+
+            Assert.Equal(2, inner.ServerCalls);
+            Assert.Equal(2, inner.GlobalCalls);
+        }
     }
 }

--- a/src/XtremeIdiots.Portal.Repository.Api.Tests.V1/XtremeIdiots.Portal.Repository.Api.Tests.V1.csproj
+++ b/src/XtremeIdiots.Portal.Repository.Api.Tests.V1/XtremeIdiots.Portal.Repository.Api.Tests.V1.csproj
@@ -20,6 +20,7 @@
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
         <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="9.0.18" />
+        <PackageReference Include="MX.Caching.Testing" Version="0.1.5" />
         <!-- Pin patched version to override vulnerable transitive (NU1903: CVE-2026-50648 and related, affected <= 10.0.9) pulled via Microsoft.NET.Test.Sdk. -->
         <PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.10" />
     </ItemGroup>

--- a/src/XtremeIdiots.Portal.Repository.Api.Tests.V2/Extensions/NoStoreCacheAttributeTests.cs
+++ b/src/XtremeIdiots.Portal.Repository.Api.Tests.V2/Extensions/NoStoreCacheAttributeTests.cs
@@ -1,0 +1,52 @@
+using System.Collections.Generic;
+
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Abstractions;
+using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.AspNetCore.Routing;
+
+using XtremeIdiots.Portal.Repository.Api.V2.Extensions;
+
+using Xunit;
+
+namespace XtremeIdiots.Portal.Repository.Api.Tests.V2.Extensions
+{
+    /// <summary>
+    /// Verifies the V2 <see cref="NoStoreCacheAttribute"/> stamps deterministic never-cache
+    /// headers on responses.
+    /// </summary>
+    public class NoStoreCacheAttributeTests
+    {
+        [Fact]
+        public void OnActionExecuted_SetsCacheControlNoStore()
+        {
+            var (attribute, context) = CreateExecutedContext();
+
+            attribute.OnActionExecuted(context);
+
+            var headers = context.HttpContext.Response.Headers;
+            Assert.Equal("no-store, no-cache, must-revalidate, max-age=0", headers.CacheControl.ToString());
+            Assert.Equal("no-cache", headers.Pragma.ToString());
+            Assert.Equal("0", headers.Expires.ToString());
+        }
+
+        [Fact]
+        public void AppliedToInfoAndHealthControllers()
+        {
+            var infoType = typeof(RepositoryWebApi.Controllers.V2.ApiInfoController);
+            var healthType = typeof(RepositoryWebApi.Controllers.V2.HealthController);
+
+            Assert.NotEmpty(infoType.GetCustomAttributes(typeof(NoStoreCacheAttribute), inherit: true));
+            Assert.NotEmpty(healthType.GetCustomAttributes(typeof(NoStoreCacheAttribute), inherit: true));
+        }
+
+        private static (NoStoreCacheAttribute attribute, ActionExecutedContext context) CreateExecutedContext()
+        {
+            var httpContext = new DefaultHttpContext();
+            var actionContext = new ActionContext(httpContext, new RouteData(), new ActionDescriptor());
+            var context = new ActionExecutedContext(actionContext, new List<IFilterMetadata>(), controller: new object());
+            return (new NoStoreCacheAttribute(), context);
+        }
+    }
+}

--- a/src/XtremeIdiots.Portal.Repository.Api.V1/Controllers/V1/ApiInfoController.cs
+++ b/src/XtremeIdiots.Portal.Repository.Api.V1/Controllers/V1/ApiInfoController.cs
@@ -2,6 +2,7 @@ using System.Reflection;
 using Asp.Versioning;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using XtremeIdiots.Portal.Repository.Api.V1.Extensions;
 using XtremeIdiots.Portal.RepositoryWebApi.Models;
 
 namespace XtremeIdiots.Portal.RepositoryWebApi.Controllers.V1;
@@ -10,6 +11,7 @@ namespace XtremeIdiots.Portal.RepositoryWebApi.Controllers.V1;
 [AllowAnonymous]
 [ApiVersion("1.0")]
 [Route("v{version:apiVersion}/info")]
+[NoStoreCache]
 public class ApiInfoController : ControllerBase
 {
     [HttpGet]

--- a/src/XtremeIdiots.Portal.Repository.Api.V1/Controllers/V1/ConnectedPlayersController.cs
+++ b/src/XtremeIdiots.Portal.Repository.Api.V1/Controllers/V1/ConnectedPlayersController.cs
@@ -666,7 +666,7 @@ namespace XtremeIdiots.Portal.RepositoryWebApi.Controllers.V1
 
             var filteredCount = await query.CountAsync(cancellationToken).ConfigureAwait(false);
 
-            query = (order ?? ConnectedPlayersOrder.LinkedAtUtcDesc) switch
+            var ordered = (order ?? ConnectedPlayersOrder.LinkedAtUtcDesc) switch
             {
                 ConnectedPlayersOrder.GameTypeAsc => query.OrderBy(cp => cp.Player.GameType).ThenByDescending(cp => cp.LinkedAtUtc),
                 ConnectedPlayersOrder.GameTypeDesc => query.OrderByDescending(cp => cp.Player.GameType).ThenByDescending(cp => cp.LinkedAtUtc),
@@ -682,7 +682,10 @@ namespace XtremeIdiots.Portal.RepositoryWebApi.Controllers.V1
                 _ => query.OrderByDescending(cp => cp.LinkedAtUtc),
             };
 
-            var entities = await query
+            // Stable tie-breaker on the unique PK — ensures Skip/Take pagination is deterministic
+            // when the primary sort column contains ties (e.g. rows sharing the same LinkedAtUtc).
+            var entities = await ordered
+                .ThenBy(cp => cp.ConnectedPlayerProfileId)
                 .Skip(skipEntries)
                 .Take(takeEntries)
                 .ToListAsync(cancellationToken)

--- a/src/XtremeIdiots.Portal.Repository.Api.V1/Controllers/V1/ConnectedPlayersController.cs
+++ b/src/XtremeIdiots.Portal.Repository.Api.V1/Controllers/V1/ConnectedPlayersController.cs
@@ -583,10 +583,12 @@ namespace XtremeIdiots.Portal.RepositoryWebApi.Controllers.V1
             [FromQuery] bool? isActive = true,
             [FromQuery] int skipEntries = 0,
             [FromQuery] int takeEntries = 20,
+            [FromQuery] string? searchString = null,
+            [FromQuery] ConnectedPlayersOrder? order = null,
             CancellationToken cancellationToken = default)
         {
             var response = await ((IConnectedPlayersApi)this)
-                .GetConnectedPlayers(playerId, userProfileId, gameType, isActive, skipEntries, takeEntries, cancellationToken)
+                .GetConnectedPlayers(playerId, userProfileId, gameType, isActive, skipEntries, takeEntries, searchString, order, cancellationToken)
                 .ConfigureAwait(false);
 
             return response.ToHttpResult();
@@ -599,12 +601,34 @@ namespace XtremeIdiots.Portal.RepositoryWebApi.Controllers.V1
             bool? isActive,
             int skipEntries,
             int takeEntries,
+            string? searchString,
+            ConnectedPlayersOrder? order,
             CancellationToken cancellationToken)
         {
-            var query = context.ConnectedPlayerProfiles
+            if (skipEntries < 0)
+            {
+                skipEntries = 0;
+            }
+
+            if (takeEntries <= 0)
+            {
+                takeEntries = 20;
+            }
+
+            if (takeEntries > 500)
+            {
+                takeEntries = 500;
+            }
+
+            var baseQuery = context.ConnectedPlayerProfiles
                 .AsNoTracking()
                 .Include(cp => cp.Player)
                 .AsQueryable();
+
+            // Unfiltered total (matches DataTables' recordsTotal semantics).
+            var totalCount = await baseQuery.CountAsync(cancellationToken).ConfigureAwait(false);
+
+            var query = baseQuery;
 
             if (playerId.HasValue)
             {
@@ -626,10 +650,39 @@ namespace XtremeIdiots.Portal.RepositoryWebApi.Controllers.V1
                 query = query.Where(cp => cp.IsActive == isActive.Value);
             }
 
+            if (!string.IsNullOrWhiteSpace(searchString))
+            {
+                var s = searchString.Trim();
+                var isGuid = Guid.TryParse(s, out var searchGuid);
+                var isGameType = Enum.TryParse<GameType>(s, ignoreCase: true, out var searchGameType);
+                var lowered = s.ToLowerInvariant();
+
+                query = query.Where(cp =>
+                    (cp.Player.Username != null && EF.Functions.Like(cp.Player.Username.ToLower(), "%" + lowered + "%"))
+                    || EF.Functions.Like(cp.LinkMethod.ToLower(), "%" + lowered + "%")
+                    || (isGuid && (cp.PlayerId == searchGuid || cp.UserProfileId == searchGuid))
+                    || (isGameType && cp.Player.GameType == (int)searchGameType));
+            }
+
             var filteredCount = await query.CountAsync(cancellationToken).ConfigureAwait(false);
 
+            query = (order ?? ConnectedPlayersOrder.LinkedAtUtcDesc) switch
+            {
+                ConnectedPlayersOrder.GameTypeAsc => query.OrderBy(cp => cp.Player.GameType).ThenByDescending(cp => cp.LinkedAtUtc),
+                ConnectedPlayersOrder.GameTypeDesc => query.OrderByDescending(cp => cp.Player.GameType).ThenByDescending(cp => cp.LinkedAtUtc),
+                ConnectedPlayersOrder.UsernameAsc => query.OrderBy(cp => cp.Player.Username).ThenByDescending(cp => cp.LinkedAtUtc),
+                ConnectedPlayersOrder.UsernameDesc => query.OrderByDescending(cp => cp.Player.Username).ThenByDescending(cp => cp.LinkedAtUtc),
+                ConnectedPlayersOrder.LinkMethodAsc => query.OrderBy(cp => cp.LinkMethod).ThenByDescending(cp => cp.LinkedAtUtc),
+                ConnectedPlayersOrder.LinkMethodDesc => query.OrderByDescending(cp => cp.LinkMethod).ThenByDescending(cp => cp.LinkedAtUtc),
+                ConnectedPlayersOrder.IsActiveAsc => query.OrderBy(cp => cp.IsActive).ThenByDescending(cp => cp.LinkedAtUtc),
+                ConnectedPlayersOrder.IsActiveDesc => query.OrderByDescending(cp => cp.IsActive).ThenByDescending(cp => cp.LinkedAtUtc),
+                ConnectedPlayersOrder.LinkedAtUtcAsc => query.OrderBy(cp => cp.LinkedAtUtc),
+                ConnectedPlayersOrder.UnlinkedAtUtcAsc => query.OrderBy(cp => cp.UnlinkedAtUtc).ThenByDescending(cp => cp.LinkedAtUtc),
+                ConnectedPlayersOrder.UnlinkedAtUtcDesc => query.OrderByDescending(cp => cp.UnlinkedAtUtc).ThenByDescending(cp => cp.LinkedAtUtc),
+                _ => query.OrderByDescending(cp => cp.LinkedAtUtc),
+            };
+
             var entities = await query
-                .OrderByDescending(cp => cp.LinkedAtUtc)
                 .Skip(skipEntries)
                 .Take(takeEntries)
                 .ToListAsync(cancellationToken)
@@ -640,7 +693,7 @@ namespace XtremeIdiots.Portal.RepositoryWebApi.Controllers.V1
             var model = new CollectionModel<ConnectedPlayerDto>(entries);
             return new ApiResponse<CollectionModel<ConnectedPlayerDto>>(model)
             {
-                Pagination = new ApiPagination(filteredCount, filteredCount, skipEntries, takeEntries)
+                Pagination = new ApiPagination(totalCount, filteredCount, skipEntries, takeEntries)
             }.ToApiResult();
         }
 

--- a/src/XtremeIdiots.Portal.Repository.Api.V1/Controllers/V1/DashboardController.cs
+++ b/src/XtremeIdiots.Portal.Repository.Api.V1/Controllers/V1/DashboardController.cs
@@ -1,8 +1,6 @@
-using System.Net;
 using Asp.Versioning;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.EntityFrameworkCore;
 
 using MX.Api.Abstractions;
 using MX.Api.Web.Extensions;
@@ -10,15 +8,15 @@ using MX.Api.Web.Extensions;
 using XtremeIdiots.Portal.Repository.Abstractions.Constants.V1;
 using XtremeIdiots.Portal.Repository.Abstractions.Interfaces.V1;
 using XtremeIdiots.Portal.Repository.Abstractions.Models.V1.Dashboard;
-using XtremeIdiots.Portal.Repository.DataLib;
-using XtremeIdiots.Portal.Repository.Api.V1.Extensions;
-using XtremeIdiots.Portal.Repository.Api.V1.TableStorage;
+using XtremeIdiots.Portal.Repository.Api.V1.Services;
 
 namespace XtremeIdiots.Portal.RepositoryWebApi.Controllers.V1;
 
 /// <summary>
 /// Controller for dashboard aggregate data, providing pre-computed summaries
-/// for the admin dashboard without requiring multiple round-trips.
+/// for the admin dashboard without requiring multiple round-trips. Delegates
+/// to <see cref="IDashboardService"/> so cache-aside behaviour can be injected
+/// via a decorator without touching controller logic.
 /// </summary>
 [ApiController]
 [Authorize(Roles = "ServiceAccount")]
@@ -26,15 +24,12 @@ namespace XtremeIdiots.Portal.RepositoryWebApi.Controllers.V1;
 [Route("v{version:apiVersion}")]
 public class DashboardController : ControllerBase, IDashboardApi
 {
-    private readonly PortalDbContext context;
-    private readonly ILiveStatusStore liveStatusStore;
+    private readonly IDashboardService dashboardService;
 
-    public DashboardController(PortalDbContext context, ILiveStatusStore liveStatusStore)
+    public DashboardController(IDashboardService dashboardService)
     {
-        ArgumentNullException.ThrowIfNull(context);
-        ArgumentNullException.ThrowIfNull(liveStatusStore);
-        this.context = context;
-        this.liveStatusStore = liveStatusStore;
+        ArgumentNullException.ThrowIfNull(dashboardService);
+        this.dashboardService = dashboardService;
     }
 
     /// <summary>
@@ -49,51 +44,8 @@ public class DashboardController : ControllerBase, IDashboardApi
         return response.ToHttpResult();
     }
 
-    async Task<ApiResult<DashboardSummaryDto>> IDashboardApi.GetDashboardSummary(CancellationToken cancellationToken)
-    {
-        var oneDayAgo = DateTime.UtcNow.AddDays(-1);
-        var sevenDaysAgo = DateTime.UtcNow.AddDays(-7);
-
-        // Server health from Table Storage live status
-        var totalServers = await context.GameServers
-            .AsNoTracking()
-            .CountAsync(gs => !gs.Deleted && gs.AgentEnabled, cancellationToken).ConfigureAwait(false);
-
-        var liveStatuses = await liveStatusStore.GetAllServerLiveStatusesAsync(cancellationToken).ConfigureAwait(false);
-        var onlineCount = liveStatuses.Count(s => s.IsOnline);
-        var totalPlayers = liveStatuses.Where(s => s.IsOnline).Sum(s => s.CurrentPlayers);
-
-        // Unclaimed ban count: permanent bans (Type == Ban) with no admin assigned
-        var unclaimedBanCount = await context.AdminActions
-            .AsNoTracking()
-            .CountAsync(a => a.Type == (int)AdminActionType.Ban
-                          && a.UserProfileId == null, cancellationToken).ConfigureAwait(false);
-
-        // Open reports
-        var openReportCount = await context.Reports
-            .AsNoTracking()
-            .CountAsync(r => !r.Closed, cancellationToken).ConfigureAwait(false);
-
-        // Recent admin actions (24h)
-        var actions24h = await GetActionCountsSince(oneDayAgo, cancellationToken).ConfigureAwait(false);
-
-        // Recent admin actions (7d)
-        var actions7d = await GetActionCountsSince(sevenDaysAgo, cancellationToken).ConfigureAwait(false);
-
-        var dto = new DashboardSummaryDto
-        {
-            TotalServers = totalServers,
-            OnlineServerCount = onlineCount,
-            OfflineServerCount = totalServers - onlineCount,
-            TotalPlayersOnline = totalPlayers,
-            UnclaimedBanCount = unclaimedBanCount,
-            OpenReportCount = openReportCount,
-            RecentActions24h = actions24h,
-            RecentActions7d = actions7d
-        };
-
-        return new ApiResponse<DashboardSummaryDto>(dto).ToApiResult();
-    }
+    Task<ApiResult<DashboardSummaryDto>> IDashboardApi.GetDashboardSummary(CancellationToken cancellationToken)
+        => dashboardService.GetDashboardSummaryAsync(cancellationToken);
 
     /// <summary>
     /// Returns admin activity leaderboard showing moderation action counts per admin
@@ -107,61 +59,8 @@ public class DashboardController : ControllerBase, IDashboardApi
         return response.ToHttpResult();
     }
 
-    async Task<ApiResult<CollectionModel<AdminLeaderboardEntryDto>>> IDashboardApi.GetAdminLeaderboard(int days, CancellationToken cancellationToken)
-    {
-        if (days <= 0)
-        {
-            days = 30;
-        }
-
-        var cutoff = DateTime.UtcNow.AddDays(-days);
-
-        var leaderboard = await context.AdminActions
-            .AsNoTracking()
-            .Where(a => a.Created >= cutoff && a.UserProfileId != null)
-            .GroupBy(a => a.UserProfileId!.Value)
-            .Select(g => new
-            {
-                AdminId = g.Key,
-                Bans = g.Count(a => a.Type == (int)AdminActionType.Ban),
-                TempBans = g.Count(a => a.Type == (int)AdminActionType.TempBan),
-                Kicks = g.Count(a => a.Type == (int)AdminActionType.Kick),
-                Warnings = g.Count(a => a.Type == (int)AdminActionType.Warning),
-                Observations = g.Count(a => a.Type == (int)AdminActionType.Observation),
-                Total = g.Count()
-            })
-            .OrderByDescending(x => x.Total)
-            .ToListAsync(cancellationToken).ConfigureAwait(false);
-
-        // Fetch display names for the admins
-        var adminIds = leaderboard.Select(x => x.AdminId).ToList();
-        var adminProfiles = await context.UserProfiles
-            .AsNoTracking()
-            .Where(up => adminIds.Contains(up.UserProfileId))
-            .Select(up => new { up.UserProfileId, up.DisplayName })
-            .ToListAsync(cancellationToken).ConfigureAwait(false);
-
-        var profileLookup = adminProfiles.ToDictionary(x => x.UserProfileId, x => x.DisplayName ?? "Unknown");
-
-        var entries = leaderboard.Select(x => new AdminLeaderboardEntryDto
-        {
-            AdminId = x.AdminId,
-            DisplayName = profileLookup.GetValueOrDefault(x.AdminId, "Unknown"),
-            Bans = x.Bans,
-            TempBans = x.TempBans,
-            Kicks = x.Kicks,
-            Warnings = x.Warnings,
-            Observations = x.Observations,
-            Total = x.Total
-        }).ToList();
-
-        var result = new CollectionModel<AdminLeaderboardEntryDto> { Items = entries };
-
-        return new ApiResponse<CollectionModel<AdminLeaderboardEntryDto>>(result)
-        {
-            Pagination = new ApiPagination(entries.Count, entries.Count, 0, entries.Count)
-        }.ToApiResult();
-    }
+    Task<ApiResult<CollectionModel<AdminLeaderboardEntryDto>>> IDashboardApi.GetAdminLeaderboard(int days, CancellationToken cancellationToken)
+        => dashboardService.GetAdminLeaderboardAsync(days, cancellationToken);
 
     /// <summary>
     /// Returns daily moderation action counts over the specified number of days,
@@ -175,48 +74,8 @@ public class DashboardController : ControllerBase, IDashboardApi
         return response.ToHttpResult();
     }
 
-    async Task<ApiResult<CollectionModel<ModerationTrendDataPointDto>>> IDashboardApi.GetModerationTrend(int days, CancellationToken cancellationToken)
-    {
-        if (days <= 0)
-        {
-            days = 30;
-        }
-
-        var cutoff = DateTime.UtcNow.AddDays(-days);
-
-        var dailyCounts = await context.AdminActions
-            .AsNoTracking()
-            .Where(a => a.Created >= cutoff)
-            .GroupBy(a => a.Created.Date)
-            .Select(g => new
-            {
-                Date = g.Key,
-                Bans = g.Count(a => a.Type == (int)AdminActionType.Ban),
-                TempBans = g.Count(a => a.Type == (int)AdminActionType.TempBan),
-                Kicks = g.Count(a => a.Type == (int)AdminActionType.Kick),
-                Warnings = g.Count(a => a.Type == (int)AdminActionType.Warning),
-                Observations = g.Count(a => a.Type == (int)AdminActionType.Observation)
-            })
-            .OrderBy(x => x.Date)
-            .ToListAsync(cancellationToken).ConfigureAwait(false);
-
-        var entries = dailyCounts.Select(x => new ModerationTrendDataPointDto
-        {
-            Date = x.Date,
-            Bans = x.Bans,
-            TempBans = x.TempBans,
-            Kicks = x.Kicks,
-            Warnings = x.Warnings,
-            Observations = x.Observations
-        }).ToList();
-
-        var result = new CollectionModel<ModerationTrendDataPointDto> { Items = entries };
-
-        return new ApiResponse<CollectionModel<ModerationTrendDataPointDto>>(result)
-        {
-            Pagination = new ApiPagination(entries.Count, entries.Count, 0, entries.Count)
-        }.ToApiResult();
-    }
+    Task<ApiResult<CollectionModel<ModerationTrendDataPointDto>>> IDashboardApi.GetModerationTrend(int days, CancellationToken cancellationToken)
+        => dashboardService.GetModerationTrendAsync(days, cancellationToken);
 
     /// <summary>
     /// Returns per-server utilization data (average and peak player counts)
@@ -230,86 +89,6 @@ public class DashboardController : ControllerBase, IDashboardApi
         return response.ToHttpResult();
     }
 
-    async Task<ApiResult<ServerUtilizationCollectionDto>> IDashboardApi.GetServerUtilization(CancellationToken cancellationToken)
-    {
-        var cutoff = DateTime.UtcNow.AddHours(-24);
-
-        // Get all agent-enabled servers
-        var servers = await context.GameServers
-            .AsNoTracking()
-            .Where(gs => !gs.Deleted && gs.AgentEnabled)
-            .Select(gs => new
-            {
-                gs.GameServerId,
-                gs.Title,
-                gs.GameType,
-            })
-            .ToListAsync(cancellationToken).ConfigureAwait(false);
-
-        // Get live status for server titles and max players
-        var liveStatuses = await liveStatusStore.GetAllServerLiveStatusesAsync(cancellationToken).ConfigureAwait(false);
-        var liveStatusLookup = liveStatuses.ToDictionary(s => s.ServerId);
-
-        // Get aggregated stats per server for the last 24 hours
-        var statsAggregates = await context.GameServerStats
-            .AsNoTracking()
-            .Where(s => s.Timestamp >= cutoff && s.GameServerId != null)
-            .GroupBy(s => s.GameServerId!.Value)
-            .Select(g => new
-            {
-                ServerId = g.Key,
-                AvgPlayers = g.Average(s => (double)s.PlayerCount),
-                PeakPlayers = g.Max(s => s.PlayerCount)
-            })
-            .ToListAsync(cancellationToken).ConfigureAwait(false);
-
-        var statsLookup = statsAggregates.ToDictionary(x => x.ServerId);
-
-        var serverDtos = servers.Select(gs =>
-        {
-            var hasStats = statsLookup.TryGetValue(gs.GameServerId, out var stats);
-            var hasLiveStatus = liveStatusLookup.TryGetValue(gs.GameServerId, out var liveStatus);
-            var maxPlayers = hasLiveStatus ? liveStatus!.MaxPlayers : 0;
-            var avg = hasStats ? stats!.AvgPlayers : 0;
-
-            return new ServerUtilizationDto
-            {
-                ServerId = gs.GameServerId,
-                Title = hasLiveStatus && !string.IsNullOrWhiteSpace(liveStatus!.Title) ? liveStatus.Title : gs.Title,
-                GameType = gs.GameType.ToGameType().ToString(),
-                AvgPlayers = Math.Round(avg, 1),
-                PeakPlayers = hasStats ? stats!.PeakPlayers : 0,
-                MaxPlayers = maxPlayers,
-                Utilization = maxPlayers > 0 ? Math.Round(avg / maxPlayers, 3) : 0
-            };
-        }).ToList();
-
-        var dto = new ServerUtilizationCollectionDto
-        {
-            Servers = serverDtos,
-            TotalAvgPlayers = Math.Round(serverDtos.Sum(s => s.AvgPlayers), 1),
-            TotalPeakPlayers = serverDtos.Sum(s => s.PeakPlayers)
-        };
-
-        return new ApiResponse<ServerUtilizationCollectionDto>(dto).ToApiResult();
-    }
-
-    private async Task<AdminActionCountsDto> GetActionCountsSince(DateTime since, CancellationToken cancellationToken)
-    {
-        var counts = await context.AdminActions
-            .AsNoTracking()
-            .Where(a => a.Created >= since)
-            .GroupBy(a => a.Type)
-            .Select(g => new { Type = g.Key, Count = g.Count() })
-            .ToListAsync(cancellationToken).ConfigureAwait(false);
-
-        return new AdminActionCountsDto
-        {
-            Bans = counts.FirstOrDefault(c => c.Type == (int)AdminActionType.Ban)?.Count ?? 0,
-            TempBans = counts.FirstOrDefault(c => c.Type == (int)AdminActionType.TempBan)?.Count ?? 0,
-            Kicks = counts.FirstOrDefault(c => c.Type == (int)AdminActionType.Kick)?.Count ?? 0,
-            Warnings = counts.FirstOrDefault(c => c.Type == (int)AdminActionType.Warning)?.Count ?? 0,
-            Observations = counts.FirstOrDefault(c => c.Type == (int)AdminActionType.Observation)?.Count ?? 0
-        };
-    }
+    Task<ApiResult<ServerUtilizationCollectionDto>> IDashboardApi.GetServerUtilization(CancellationToken cancellationToken)
+        => dashboardService.GetServerUtilizationAsync(cancellationToken);
 }

--- a/src/XtremeIdiots.Portal.Repository.Api.V1/Controllers/V1/GameServerConfigurationsController.cs
+++ b/src/XtremeIdiots.Portal.Repository.Api.V1/Controllers/V1/GameServerConfigurationsController.cs
@@ -15,6 +15,8 @@ using XtremeIdiots.Portal.Repository.Abstractions.Constants.V1;
 using XtremeIdiots.Portal.Repository.Abstractions.Interfaces.V1;
 using XtremeIdiots.Portal.Repository.Abstractions.Models.V1.Configurations;
 using XtremeIdiots.Portal.Repository.Api.V1.Mapping;
+using XtremeIdiots.Portal.Repository.Api.V1.Services;
+using XtremeIdiots.Portal.Repository.Api.V1.Services.Caching;
 using XtremeIdiots.Portal.Repository.Api.V1.Validation;
 
 namespace XtremeIdiots.Portal.RepositoryWebApi.Controllers.V1;
@@ -26,11 +28,20 @@ namespace XtremeIdiots.Portal.RepositoryWebApi.Controllers.V1;
 public class GameServerConfigurationsController : ControllerBase, IGameServerConfigurationsApi
 {
     private readonly PortalDbContext context;
+    private readonly IConfigurationReadService configurationReadService;
+    private readonly IRepositoryCacheInvalidator cacheInvalidator;
 
-    public GameServerConfigurationsController(PortalDbContext context)
+    public GameServerConfigurationsController(
+        PortalDbContext context,
+        IConfigurationReadService configurationReadService,
+        IRepositoryCacheInvalidator cacheInvalidator)
     {
         ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(configurationReadService);
+        ArgumentNullException.ThrowIfNull(cacheInvalidator);
         this.context = context;
+        this.configurationReadService = configurationReadService;
+        this.cacheInvalidator = cacheInvalidator;
     }
 
     [HttpGet("game-servers/{gameServerId:guid}/configurations")]
@@ -73,21 +84,7 @@ public class GameServerConfigurationsController : ControllerBase, IGameServerCon
 
     async Task<ApiResult<ConfigurationDto>> IGameServerConfigurationsApi.GetConfiguration(Guid gameServerId, string ns, CancellationToken cancellationToken)
     {
-        if (string.IsNullOrWhiteSpace(ns) || ns.Length > 128)
-        {
-            return new ApiResult<ConfigurationDto>(HttpStatusCode.BadRequest);
-        }
-
-        var config = await context.GameServerConfigurations
-            .AsNoTracking()
-            .FirstOrDefaultAsync(c => c.GameServerId == gameServerId && c.Namespace == ns, cancellationToken).ConfigureAwait(false);
-
-        if (config == null)
-        {
-            return new ApiResult<ConfigurationDto>(HttpStatusCode.NotFound);
-        }
-
-        return new ApiResponse<ConfigurationDto>(config.ToDto()).ToApiResult();
+        return await configurationReadService.GetServerConfigurationAsync(gameServerId, ns, cancellationToken).ConfigureAwait(false);
     }
 
     [HttpPut("game-servers/{gameServerId:guid}/configurations/{ns}")]
@@ -168,6 +165,7 @@ public class GameServerConfigurationsController : ControllerBase, IGameServerCon
         }
 
         await context.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+        await cacheInvalidator.InvalidateServerSettingsAsync(gameServerId, ns, cancellationToken).ConfigureAwait(false);
         return new ApiResponse().ToApiResult();
     }
 
@@ -197,6 +195,7 @@ public class GameServerConfigurationsController : ControllerBase, IGameServerCon
 
         context.GameServerConfigurations.Remove(config);
         await context.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+        await cacheInvalidator.InvalidateServerSettingsAsync(gameServerId, ns, cancellationToken).ConfigureAwait(false);
         return new ApiResult(HttpStatusCode.NoContent);
     }
 }

--- a/src/XtremeIdiots.Portal.Repository.Api.V1/Controllers/V1/GameServersController.cs
+++ b/src/XtremeIdiots.Portal.Repository.Api.V1/Controllers/V1/GameServersController.cs
@@ -17,6 +17,8 @@ using XtremeIdiots.Portal.Repository.Abstractions.Interfaces.V1;
 using XtremeIdiots.Portal.Repository.Abstractions.Models.V1.GameServers;
 using XtremeIdiots.Portal.Repository.Api.V1.Extensions;
 using XtremeIdiots.Portal.Repository.Api.V1.Mapping;
+using XtremeIdiots.Portal.Repository.Api.V1.Services;
+using XtremeIdiots.Portal.Repository.Api.V1.Services.Caching;
 
 namespace XtremeIdiots.Portal.RepositoryWebApi.Controllers.V1;
 
@@ -27,13 +29,21 @@ namespace XtremeIdiots.Portal.RepositoryWebApi.Controllers.V1;
 public class GameServersController : ControllerBase, IGameServersApi
 {
     private readonly PortalDbContext context;
+    private readonly IGameServerReadService gameServerReadService;
+    private readonly IRepositoryCacheInvalidator cacheInvalidator;
 
 
     public GameServersController(
-        PortalDbContext context)
+        PortalDbContext context,
+        IGameServerReadService gameServerReadService,
+        IRepositoryCacheInvalidator cacheInvalidator)
     {
         ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(gameServerReadService);
+        ArgumentNullException.ThrowIfNull(cacheInvalidator);
         this.context = context;
+        this.gameServerReadService = gameServerReadService;
+        this.cacheInvalidator = cacheInvalidator;
     }
 
     /// <summary>
@@ -60,19 +70,7 @@ public class GameServersController : ControllerBase, IGameServersApi
     /// <returns>An API result containing the game server details if found; otherwise, a 404 Not Found response.</returns>
     async Task<ApiResult<GameServerDto>> IGameServersApi.GetGameServer(Guid gameServerId, CancellationToken cancellationToken)
     {
-        var gameServer = await context.GameServers
-            .Include(gs => gs.BanFileMonitors)
-            .AsNoTracking()
-            .FirstOrDefaultAsync(gs => gs.GameServerId == gameServerId && !gs.Deleted, cancellationToken).ConfigureAwait(false);
-
-        if (gameServer == null)
-        {
-            return new ApiResult<GameServerDto>(HttpStatusCode.NotFound);
-        }
-
-        var result = gameServer.ToDto();
-
-        return new ApiResponse<GameServerDto>(result).ToApiResult();
+        return await gameServerReadService.GetGameServerAsync(gameServerId, cancellationToken).ConfigureAwait(false);
     }
 
     /// <summary>
@@ -173,6 +171,8 @@ public class GameServersController : ControllerBase, IGameServersApi
 
         context.GameServers.Add(gameServer);
         await context.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+        await cacheInvalidator.InvalidateGameServerAsync(gameServer.GameServerId, cancellationToken).ConfigureAwait(false);
+        await cacheInvalidator.InvalidateDashboardAsync(cancellationToken).ConfigureAwait(false);
         return new ApiResponse().ToApiResult(HttpStatusCode.Created);
     }
 
@@ -233,6 +233,12 @@ public class GameServersController : ControllerBase, IGameServersApi
 
         await context.GameServers.AddRangeAsync(gameServers, cancellationToken).ConfigureAwait(false);
         await context.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+
+        foreach (var gs in gameServers)
+        {
+            await cacheInvalidator.InvalidateGameServerAsync(gs.GameServerId, cancellationToken).ConfigureAwait(false);
+        }
+        await cacheInvalidator.InvalidateDashboardAsync(cancellationToken).ConfigureAwait(false);
 
         return new ApiResponse().ToApiResult();
     }
@@ -306,6 +312,8 @@ public class GameServersController : ControllerBase, IGameServersApi
         }
 
         await context.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+        await cacheInvalidator.InvalidateGameServerAsync(gameServer.GameServerId, cancellationToken).ConfigureAwait(false);
+        await cacheInvalidator.InvalidateDashboardAsync(cancellationToken).ConfigureAwait(false);
         return new ApiResponse().ToApiResult();
     }
 
@@ -413,6 +421,12 @@ public class GameServersController : ControllerBase, IGameServersApi
 
         await context.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
 
+        foreach (var id in requestedIds)
+        {
+            await cacheInvalidator.InvalidateGameServerAsync(id, cancellationToken).ConfigureAwait(false);
+        }
+        await cacheInvalidator.InvalidateDashboardAsync(cancellationToken).ConfigureAwait(false);
+
         return new ApiResponse().ToApiResult();
     }
 
@@ -437,6 +451,8 @@ public class GameServersController : ControllerBase, IGameServersApi
 
         gameServer.Deleted = true;
         await context.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+        await cacheInvalidator.InvalidateGameServerAsync(gameServer.GameServerId, cancellationToken).ConfigureAwait(false);
+        await cacheInvalidator.InvalidateDashboardAsync(cancellationToken).ConfigureAwait(false);
         return new ApiResponse().ToApiResult();
     }
 

--- a/src/XtremeIdiots.Portal.Repository.Api.V1/Controllers/V1/GlobalConfigurationsController.cs
+++ b/src/XtremeIdiots.Portal.Repository.Api.V1/Controllers/V1/GlobalConfigurationsController.cs
@@ -15,6 +15,8 @@ using XtremeIdiots.Portal.Repository.Abstractions.Constants.V1;
 using XtremeIdiots.Portal.Repository.Abstractions.Interfaces.V1;
 using XtremeIdiots.Portal.Repository.Abstractions.Models.V1.Configurations;
 using XtremeIdiots.Portal.Repository.Api.V1.Mapping;
+using XtremeIdiots.Portal.Repository.Api.V1.Services;
+using XtremeIdiots.Portal.Repository.Api.V1.Services.Caching;
 using XtremeIdiots.Portal.Repository.Api.V1.Validation;
 using ServerListContractConstants = XtremeIdiots.Portal.Settings.Contracts.V1.Contracts.ServerList.ServerListSettingsConstants;
 
@@ -31,11 +33,20 @@ public class GlobalConfigurationsController : ControllerBase, IGlobalConfigurati
     private static readonly string LegacyServerListNamespaceLower = LegacyServerListNamespace.ToLowerInvariant();
 
     private readonly PortalDbContext context;
+    private readonly IConfigurationReadService configurationReadService;
+    private readonly IRepositoryCacheInvalidator cacheInvalidator;
 
-    public GlobalConfigurationsController(PortalDbContext context)
+    public GlobalConfigurationsController(
+        PortalDbContext context,
+        IConfigurationReadService configurationReadService,
+        IRepositoryCacheInvalidator cacheInvalidator)
     {
         ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(configurationReadService);
+        ArgumentNullException.ThrowIfNull(cacheInvalidator);
         this.context = context;
+        this.configurationReadService = configurationReadService;
+        this.cacheInvalidator = cacheInvalidator;
     }
 
     [HttpGet("configurations")]
@@ -74,40 +85,7 @@ public class GlobalConfigurationsController : ControllerBase, IGlobalConfigurati
             return new ApiResult<ConfigurationDto>(HttpStatusCode.BadRequest);
         }
 
-        ns = NamespaceSchemaValidationRegistry.NormalizeNamespace(ns);
-
-        var isServerListNamespace = string.Equals(ns, ServerListContractConstants.Namespace, StringComparison.OrdinalIgnoreCase);
-
-        GlobalConfiguration? config;
-        if (isServerListNamespace)
-        {
-            var configs = await context.GlobalConfigurations
-                .AsNoTracking()
-                .Where(c =>
-                    c.Namespace.ToLower() == CanonicalServerListNamespaceLower ||
-                    c.Namespace.ToLower() == LegacyServerListNamespaceLower)
-                .ToListAsync(cancellationToken).ConfigureAwait(false);
-
-            config = configs.FirstOrDefault(c => string.Equals(c.Namespace, ServerListContractConstants.Namespace, StringComparison.Ordinal))
-                ?? configs.FirstOrDefault(c => string.Equals(c.Namespace, LegacyServerListNamespace, StringComparison.Ordinal))
-                ?? configs
-                    .OrderByDescending(c => c.LastModifiedUtc)
-                    .ThenBy(c => c.Namespace, StringComparer.Ordinal)
-                    .FirstOrDefault();
-        }
-        else
-        {
-            config = await context.GlobalConfigurations
-                .AsNoTracking()
-                .FirstOrDefaultAsync(c => c.Namespace == ns, cancellationToken).ConfigureAwait(false);
-        }
-
-        if (config == null)
-        {
-            return new ApiResult<ConfigurationDto>(HttpStatusCode.NotFound);
-        }
-
-        return new ApiResponse<ConfigurationDto>(config.ToDto()).ToApiResult();
+        return await configurationReadService.GetGlobalConfigurationAsync(ns, cancellationToken).ConfigureAwait(false);
     }
 
     [HttpPut("configurations/{ns}")]
@@ -222,6 +200,7 @@ public class GlobalConfigurationsController : ControllerBase, IGlobalConfigurati
         }
 
         await context.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+        await cacheInvalidator.InvalidateGlobalNamespaceAsync(ns, cancellationToken).ConfigureAwait(false);
         return new ApiResponse().ToApiResult();
     }
 
@@ -274,6 +253,7 @@ public class GlobalConfigurationsController : ControllerBase, IGlobalConfigurati
         }
 
         await context.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+        await cacheInvalidator.InvalidateGlobalNamespaceAsync(ns, cancellationToken).ConfigureAwait(false);
         return new ApiResponse().ToApiResult();
     }
 }

--- a/src/XtremeIdiots.Portal.Repository.Api.V1/Controllers/V1/HealthController.cs
+++ b/src/XtremeIdiots.Portal.Repository.Api.V1/Controllers/V1/HealthController.cs
@@ -2,6 +2,7 @@ using Asp.Versioning;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
+using XtremeIdiots.Portal.Repository.Api.V1.Extensions;
 
 namespace XtremeIdiots.Portal.RepositoryWebApi.Controllers.V1;
 
@@ -9,6 +10,7 @@ namespace XtremeIdiots.Portal.RepositoryWebApi.Controllers.V1;
 [AllowAnonymous]
 [ApiVersion("1.0")]
 [Route("v{version:apiVersion}/health")]
+[NoStoreCache]
 public class HealthController : ControllerBase
 {
     private readonly HealthCheckService _healthCheckService;

--- a/src/XtremeIdiots.Portal.Repository.Api.V1/Extensions/NoStoreCacheAttribute.cs
+++ b/src/XtremeIdiots.Portal.Repository.Api.V1/Extensions/NoStoreCacheAttribute.cs
@@ -1,0 +1,24 @@
+using Microsoft.AspNetCore.Mvc.Filters;
+
+namespace XtremeIdiots.Portal.Repository.Api.V1.Extensions
+{
+    /// <summary>
+    /// Action filter that stamps <c>Cache-Control: no-store, no-cache</c>, <c>Pragma: no-cache</c>
+    /// and <c>Expires: 0</c> on the response. Applied to endpoints that must never be served
+    /// from any cache (client, CDN, APIM, browser) — most importantly <c>/info</c> which drives
+    /// deploy version verification and <c>/health/*</c> which must reflect live status.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Method, AllowMultiple = false, Inherited = true)]
+    public sealed class NoStoreCacheAttribute : Attribute, IActionFilter
+    {
+        public void OnActionExecuting(ActionExecutingContext context) { }
+
+        public void OnActionExecuted(ActionExecutedContext context)
+        {
+            var headers = context.HttpContext.Response.Headers;
+            headers.CacheControl = "no-store, no-cache, must-revalidate, max-age=0";
+            headers.Pragma = "no-cache";
+            headers.Expires = "0";
+        }
+    }
+}

--- a/src/XtremeIdiots.Portal.Repository.Api.V1/Program.cs
+++ b/src/XtremeIdiots.Portal.Repository.Api.V1/Program.cs
@@ -10,9 +10,12 @@ using Newtonsoft.Json.Converters;
 using XtremeIdiots.Portal.Repository.DataLib;
 using XtremeIdiots.Portal.Repository.Api.V1;
 using XtremeIdiots.Portal.Repository.Api.V1.Serialization;
+using XtremeIdiots.Portal.Repository.Api.V1.Services;
+using XtremeIdiots.Portal.Repository.Api.V1.Services.Caching;
 using XtremeIdiots.Portal.Repository.Api.V1.TableStorage;
 using Asp.Versioning;
 using XtremeIdiots.Portal.Repository.Api.V1.OpenApi;
+using MX.Caching;
 using MX.Observability.ApplicationInsights.AspNetCore;
 using Scalar.AspNetCore;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
@@ -127,8 +130,15 @@ builder.Services.AddHealthChecks()
         name: "sql-database",
         tags: ["dependency"]);
 
-// Register Table Storage for live status
-var tableEndpoint = builder.Configuration["appdata_storage_table_endpoint"];
+// Register Table Storage for live status.
+// Prefer the shared cache Table Storage endpoint published by portal-core
+// (managed-identity only, no keys). Fall back to the legacy appdata storage
+// endpoint / connection string only when the shared endpoint is not yet
+// wired — this keeps dev-boxes and non-migrated environments booting cleanly.
+var sharedCacheTableEndpoint = builder.Configuration["shared_cache_storage_table_endpoint"];
+var legacyTableEndpoint = builder.Configuration["appdata_storage_table_endpoint"];
+var tableEndpoint = !string.IsNullOrWhiteSpace(sharedCacheTableEndpoint) ? sharedCacheTableEndpoint : legacyTableEndpoint;
+
 if (!string.IsNullOrWhiteSpace(tableEndpoint))
 {
     var managedIdentityClientId = builder.Configuration["AzureAppConfiguration:ManagedIdentityClientId"];
@@ -154,7 +164,41 @@ else
     }
 }
 
+// Register MX.Caching. When the `MxCaching` section is configured with
+// `Backend=TableStorage` and a `TableStorage:Endpoint`, MX.Caching self-creates
+// its own configured table on startup; portal-core does not pre-provision it.
+// When the section is absent (dev/tests) MX.Caching falls back to an in-memory
+// backend, and the caching decorators remain functional (per-instance only).
+var mxCachingConfigured = builder.Configuration.GetSection("MxCaching").GetChildren().Any();
+builder.Services.AddMxCaching(builder.Configuration);
+
+// Repository read-service seams + optional cache-aside decorators.
+builder.Services.AddRepositoryReadServices(enableCaching: mxCachingConfigured);
+
 var app = builder.Build();
+
+// MI-safe creation of LiveStatus tables. portal-core provisions the shared
+// cache Storage Account without SAS keys and does not pre-create tables to
+// keep `shared_access_key_enabled=false`. TableStorageLiveStatusStore relies
+// on these tables existing, so bootstrap them here via managed identity
+// before we start serving requests.
+using (var scope = app.Services.CreateScope())
+{
+    var tableSvc = scope.ServiceProvider.GetService<TableServiceClient>();
+    if (tableSvc != null)
+    {
+        try
+        {
+            await tableSvc.CreateTableIfNotExistsAsync("GameServerLiveStatus").ConfigureAwait(false);
+            await tableSvc.CreateTableIfNotExistsAsync("GameServerLivePlayers").ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            var logger = scope.ServiceProvider.GetRequiredService<ILoggerFactory>().CreateLogger("Startup.LiveStatusTables");
+            logger.LogError(ex, "Failed to ensure LiveStatus tables exist. LiveStatus writes will fail until this is resolved.");
+        }
+    }
+}
 
 if (isAzureAppConfigurationEnabled)
 {

--- a/src/XtremeIdiots.Portal.Repository.Api.V1/Services/Caching/CachingConfigurationReadService.cs
+++ b/src/XtremeIdiots.Portal.Repository.Api.V1/Services/Caching/CachingConfigurationReadService.cs
@@ -32,7 +32,10 @@ namespace XtremeIdiots.Portal.Repository.Api.V1.Services.Caching
 
         public async Task<ApiResult<ConfigurationDto>> GetServerConfigurationAsync(Guid gameServerId, string ns, CancellationToken cancellationToken)
         {
-            if (string.IsNullOrWhiteSpace(ns))
+            // Defence-in-depth: mirror the inner service's rejection of oversized namespaces so
+            // an oversized value never reaches key/tag construction. Callers going through
+            // controllers already short-circuit on the same guard.
+            if (string.IsNullOrWhiteSpace(ns) || ns.Length > 128)
             {
                 return await inner.GetServerConfigurationAsync(gameServerId, ns, cancellationToken).ConfigureAwait(false);
             }
@@ -75,7 +78,7 @@ namespace XtremeIdiots.Portal.Repository.Api.V1.Services.Caching
 
         public async Task<ApiResult<ConfigurationDto>> GetGlobalConfigurationAsync(string ns, CancellationToken cancellationToken)
         {
-            if (string.IsNullOrWhiteSpace(ns))
+            if (string.IsNullOrWhiteSpace(ns) || ns.Length > 128)
             {
                 return await inner.GetGlobalConfigurationAsync(ns, cancellationToken).ConfigureAwait(false);
             }

--- a/src/XtremeIdiots.Portal.Repository.Api.V1/Services/Caching/CachingConfigurationReadService.cs
+++ b/src/XtremeIdiots.Portal.Repository.Api.V1/Services/Caching/CachingConfigurationReadService.cs
@@ -1,0 +1,116 @@
+using MX.Api.Abstractions;
+using MX.Caching.Abstractions;
+
+using XtremeIdiots.Portal.Repository.Abstractions.Models.V1.Configurations;
+using XtremeIdiots.Portal.Repository.Api.V1.Validation;
+
+namespace XtremeIdiots.Portal.Repository.Api.V1.Services.Caching
+{
+    /// <summary>
+    /// Cache-aside decorator over <see cref="IConfigurationReadService"/>. Entries are stored
+    /// with a 5-minute TTL and dual tags — one precise, one namespace-scoped — so a global
+    /// upsert can invalidate every server's resolved entry for that namespace across all
+    /// Repository API instances via the shared Table Storage tag index.
+    /// </summary>
+    public sealed class CachingConfigurationReadService : IConfigurationReadService
+    {
+        internal static readonly TimeSpan Ttl = TimeSpan.FromMinutes(5);
+
+        private readonly IConfigurationReadService inner;
+        private readonly IMxCache cache;
+        private readonly RepositoryCacheMetrics metrics;
+
+        public CachingConfigurationReadService(IConfigurationReadService inner, IMxCache cache, RepositoryCacheMetrics metrics)
+        {
+            ArgumentNullException.ThrowIfNull(inner);
+            ArgumentNullException.ThrowIfNull(cache);
+            ArgumentNullException.ThrowIfNull(metrics);
+            this.inner = inner;
+            this.cache = cache;
+            this.metrics = metrics;
+        }
+
+        public async Task<ApiResult<ConfigurationDto>> GetServerConfigurationAsync(Guid gameServerId, string ns, CancellationToken cancellationToken)
+        {
+            if (string.IsNullOrWhiteSpace(ns))
+            {
+                return await inner.GetServerConfigurationAsync(gameServerId, ns, cancellationToken).ConfigureAwait(false);
+            }
+
+            // Normalize the namespace (e.g. legacy alias "serverList" -> canonical) so cache
+            // keys/tags stay aligned with those used by the write-path invalidator; otherwise
+            // an alias-scoped entry would survive canonical-scoped invalidation until TTL.
+            ns = NamespaceSchemaValidationRegistry.NormalizeNamespace(ns);
+
+            var key = new CacheKey(RepositoryCacheKeys.SettingsServerKey(gameServerId, ns));
+
+            var existing = await cache.TryGetAsync<ApiResult<ConfigurationDto>>(key, cancellationToken).ConfigureAwait(false);
+            if (existing.Found)
+            {
+                metrics.RecordHit(RepositoryCacheKeys.SurfaceSettings);
+                return existing.Value!;
+            }
+
+            metrics.RecordMiss(RepositoryCacheKeys.SurfaceSettings);
+            var fetched = await inner.GetServerConfigurationAsync(gameServerId, ns, cancellationToken).ConfigureAwait(false);
+
+            if (fetched.IsSuccess)
+            {
+                var policy = new CachePolicy
+                {
+                    Enabled = true,
+                    Tier = CacheTier.Distributed,
+                    Ttl = Ttl,
+                    Tags = new[]
+                    {
+                        RepositoryCacheKeys.SettingsServerTag(gameServerId, ns),
+                        RepositoryCacheKeys.SettingsNamespaceTag(ns)
+                    }
+                };
+                await cache.SetAsync(key, fetched, policy, cancellationToken).ConfigureAwait(false);
+            }
+
+            return fetched;
+        }
+
+        public async Task<ApiResult<ConfigurationDto>> GetGlobalConfigurationAsync(string ns, CancellationToken cancellationToken)
+        {
+            if (string.IsNullOrWhiteSpace(ns))
+            {
+                return await inner.GetGlobalConfigurationAsync(ns, cancellationToken).ConfigureAwait(false);
+            }
+
+            ns = NamespaceSchemaValidationRegistry.NormalizeNamespace(ns);
+
+            var key = new CacheKey(RepositoryCacheKeys.SettingsGlobalKey(ns));
+
+            var existing = await cache.TryGetAsync<ApiResult<ConfigurationDto>>(key, cancellationToken).ConfigureAwait(false);
+            if (existing.Found)
+            {
+                metrics.RecordHit(RepositoryCacheKeys.SurfaceSettings);
+                return existing.Value!;
+            }
+
+            metrics.RecordMiss(RepositoryCacheKeys.SurfaceSettings);
+            var fetched = await inner.GetGlobalConfigurationAsync(ns, cancellationToken).ConfigureAwait(false);
+
+            if (fetched.IsSuccess)
+            {
+                var policy = new CachePolicy
+                {
+                    Enabled = true,
+                    Tier = CacheTier.Distributed,
+                    Ttl = Ttl,
+                    Tags = new[]
+                    {
+                        RepositoryCacheKeys.SettingsGlobalTag(ns),
+                        RepositoryCacheKeys.SettingsNamespaceTag(ns)
+                    }
+                };
+                await cache.SetAsync(key, fetched, policy, cancellationToken).ConfigureAwait(false);
+            }
+
+            return fetched;
+        }
+    }
+}

--- a/src/XtremeIdiots.Portal.Repository.Api.V1/Services/Caching/CachingDashboardService.cs
+++ b/src/XtremeIdiots.Portal.Repository.Api.V1/Services/Caching/CachingDashboardService.cs
@@ -1,0 +1,83 @@
+using MX.Api.Abstractions;
+using MX.Caching.Abstractions;
+
+using XtremeIdiots.Portal.Repository.Abstractions.Models.V1.Dashboard;
+
+namespace XtremeIdiots.Portal.Repository.Api.V1.Services.Caching
+{
+    /// <summary>
+    /// Cache-aside decorator over <see cref="IDashboardService"/>. All four aggregations are
+    /// stored with a 90-second TTL (mid-point of the 60–120s window in the work package) and
+    /// tagged <c>dashboard</c> so any admin action mutation can evict the whole surface via
+    /// <see cref="IRepositoryCacheInvalidator.InvalidateDashboardAsync"/>.
+    /// </summary>
+    public sealed class CachingDashboardService : IDashboardService
+    {
+        internal static readonly TimeSpan Ttl = TimeSpan.FromSeconds(90);
+
+        private readonly IDashboardService inner;
+        private readonly IMxCache cache;
+        private readonly RepositoryCacheMetrics metrics;
+
+        public CachingDashboardService(IDashboardService inner, IMxCache cache, RepositoryCacheMetrics metrics)
+        {
+            ArgumentNullException.ThrowIfNull(inner);
+            ArgumentNullException.ThrowIfNull(cache);
+            ArgumentNullException.ThrowIfNull(metrics);
+            this.inner = inner;
+            this.cache = cache;
+            this.metrics = metrics;
+        }
+
+        public Task<ApiResult<DashboardSummaryDto>> GetDashboardSummaryAsync(CancellationToken cancellationToken)
+            => GetOrCreateAsync("summary", "current",
+                (ct) => inner.GetDashboardSummaryAsync(ct),
+                cancellationToken);
+
+        public Task<ApiResult<CollectionModel<AdminLeaderboardEntryDto>>> GetAdminLeaderboardAsync(int days, CancellationToken cancellationToken)
+            => GetOrCreateAsync("admin-leaderboard", DaysWindow(days),
+                (ct) => inner.GetAdminLeaderboardAsync(days, ct),
+                cancellationToken);
+
+        public Task<ApiResult<CollectionModel<ModerationTrendDataPointDto>>> GetModerationTrendAsync(int days, CancellationToken cancellationToken)
+            => GetOrCreateAsync("moderation-trend", DaysWindow(days),
+                (ct) => inner.GetModerationTrendAsync(days, ct),
+                cancellationToken);
+
+        public Task<ApiResult<ServerUtilizationCollectionDto>> GetServerUtilizationAsync(CancellationToken cancellationToken)
+            => GetOrCreateAsync("server-utilization", "24h",
+                (ct) => inner.GetServerUtilizationAsync(ct),
+                cancellationToken);
+
+        private async Task<ApiResult<T>> GetOrCreateAsync<T>(string metric, string window, Func<CancellationToken, Task<ApiResult<T>>> factory, CancellationToken cancellationToken)
+        {
+            var key = new CacheKey(RepositoryCacheKeys.DashboardKey(metric, window));
+
+            var existing = await cache.TryGetAsync<ApiResult<T>>(key, cancellationToken).ConfigureAwait(false);
+            if (existing.Found)
+            {
+                metrics.RecordHit(RepositoryCacheKeys.SurfaceDashboard);
+                return existing.Value!;
+            }
+
+            metrics.RecordMiss(RepositoryCacheKeys.SurfaceDashboard);
+            var fetched = await factory(cancellationToken).ConfigureAwait(false);
+
+            if (fetched.IsSuccess)
+            {
+                var policy = new CachePolicy
+                {
+                    Enabled = true,
+                    Tier = CacheTier.Distributed,
+                    Ttl = Ttl,
+                    Tags = new[] { RepositoryCacheKeys.DashboardTag }
+                };
+                await cache.SetAsync(key, fetched, policy, cancellationToken).ConfigureAwait(false);
+            }
+
+            return fetched;
+        }
+
+        private static string DaysWindow(int days) => days <= 0 ? "30d" : $"{days}d";
+    }
+}

--- a/src/XtremeIdiots.Portal.Repository.Api.V1/Services/Caching/CachingGameServerReadService.cs
+++ b/src/XtremeIdiots.Portal.Repository.Api.V1/Services/Caching/CachingGameServerReadService.cs
@@ -1,0 +1,65 @@
+using MX.Api.Abstractions;
+using MX.Caching.Abstractions;
+
+using XtremeIdiots.Portal.Repository.Abstractions.Models.V1.GameServers;
+
+namespace XtremeIdiots.Portal.Repository.Api.V1.Services.Caching
+{
+    /// <summary>
+    /// Cache-aside decorator over <see cref="IGameServerReadService"/>. Successful reads are
+    /// stored under <c>gameserver:{id}</c> with a matching tag so mutation-side controllers can
+    /// evict via <see cref="IRepositoryCacheInvalidator"/>. Non-success results (e.g. 404) are
+    /// never cached to avoid pinning a stale negative.
+    /// </summary>
+    public sealed class CachingGameServerReadService : IGameServerReadService
+    {
+        internal static readonly TimeSpan Ttl = TimeSpan.FromSeconds(60);
+
+        private readonly IGameServerReadService inner;
+        private readonly IMxCache cache;
+        private readonly RepositoryCacheMetrics metrics;
+
+        public CachingGameServerReadService(IGameServerReadService inner, IMxCache cache, RepositoryCacheMetrics metrics)
+        {
+            ArgumentNullException.ThrowIfNull(inner);
+            ArgumentNullException.ThrowIfNull(cache);
+            ArgumentNullException.ThrowIfNull(metrics);
+            this.inner = inner;
+            this.cache = cache;
+            this.metrics = metrics;
+        }
+
+        public async Task<ApiResult<GameServerDto>> GetGameServerAsync(Guid gameServerId, CancellationToken cancellationToken)
+        {
+            var key = new CacheKey(RepositoryCacheKeys.GameServerKey(gameServerId));
+            var tag = RepositoryCacheKeys.GameServerTag(gameServerId);
+
+            var existing = await cache.TryGetAsync<ApiResult<GameServerDto>>(key, cancellationToken).ConfigureAwait(false);
+            if (existing.Found)
+            {
+                metrics.RecordHit(RepositoryCacheKeys.SurfaceGameServer);
+                return existing.Value!;
+            }
+
+            metrics.RecordMiss(RepositoryCacheKeys.SurfaceGameServer);
+            var fetched = await inner.GetGameServerAsync(gameServerId, cancellationToken).ConfigureAwait(false);
+
+            // Only cache successful reads. Errors and 404s stay uncached so a subsequent create
+            // is picked up immediately.
+            if (fetched.IsSuccess)
+            {
+                var policy = new CachePolicy
+                {
+                    Enabled = true,
+                    Tier = CacheTier.Distributed,
+                    Ttl = Ttl,
+                    Tags = new[] { tag }
+                };
+
+                await cache.SetAsync(key, fetched, policy, cancellationToken).ConfigureAwait(false);
+            }
+
+            return fetched;
+        }
+    }
+}

--- a/src/XtremeIdiots.Portal.Repository.Api.V1/Services/Caching/IRepositoryCacheInvalidator.cs
+++ b/src/XtremeIdiots.Portal.Repository.Api.V1/Services/Caching/IRepositoryCacheInvalidator.cs
@@ -1,0 +1,24 @@
+namespace XtremeIdiots.Portal.Repository.Api.V1.Services.Caching
+{
+    /// <summary>
+    /// High-level, surface-aware cache-invalidation seam used by mutation-side controllers
+    /// so they don't need direct <see cref="MX.Caching.Abstractions.IMxCache"/> knowledge.
+    /// Each invalidation resolves to <c>RemoveByTagAsync</c> against the shared cache backend
+    /// so it takes effect across all Repository API instances via the tag index.
+    /// </summary>
+    public interface IRepositoryCacheInvalidator
+    {
+        /// <summary>Invalidates every cached read for a single game server.</summary>
+        Task InvalidateGameServerAsync(Guid gameServerId, CancellationToken cancellationToken = default);
+
+        /// <summary>Invalidates all cached dashboard aggregations.</summary>
+        Task InvalidateDashboardAsync(CancellationToken cancellationToken = default);
+
+        /// <summary>Invalidates the cached resolved settings document for one server + namespace.</summary>
+        Task InvalidateServerSettingsAsync(Guid gameServerId, string ns, CancellationToken cancellationToken = default);
+
+        /// <summary>Invalidates the cached global settings document for a namespace and every
+        /// server-resolved entry for that namespace across all instances.</summary>
+        Task InvalidateGlobalNamespaceAsync(string ns, CancellationToken cancellationToken = default);
+    }
+}

--- a/src/XtremeIdiots.Portal.Repository.Api.V1/Services/Caching/NoOpRepositoryCacheInvalidator.cs
+++ b/src/XtremeIdiots.Portal.Repository.Api.V1/Services/Caching/NoOpRepositoryCacheInvalidator.cs
@@ -1,0 +1,14 @@
+namespace XtremeIdiots.Portal.Repository.Api.V1.Services.Caching
+{
+    /// <summary>
+    /// No-op invalidator registered when the shared cache is not configured. Keeps controllers
+    /// free of null checks by making the eviction call an inexpensive completed <see cref="Task"/>.
+    /// </summary>
+    public sealed class NoOpRepositoryCacheInvalidator : IRepositoryCacheInvalidator
+    {
+        public Task InvalidateGameServerAsync(Guid gameServerId, CancellationToken cancellationToken = default) => Task.CompletedTask;
+        public Task InvalidateDashboardAsync(CancellationToken cancellationToken = default) => Task.CompletedTask;
+        public Task InvalidateServerSettingsAsync(Guid gameServerId, string ns, CancellationToken cancellationToken = default) => Task.CompletedTask;
+        public Task InvalidateGlobalNamespaceAsync(string ns, CancellationToken cancellationToken = default) => Task.CompletedTask;
+    }
+}

--- a/src/XtremeIdiots.Portal.Repository.Api.V1/Services/Caching/RepositoryCacheInvalidator.cs
+++ b/src/XtremeIdiots.Portal.Repository.Api.V1/Services/Caching/RepositoryCacheInvalidator.cs
@@ -1,5 +1,7 @@
 using MX.Caching.Abstractions;
 
+using XtremeIdiots.Portal.Repository.Api.V1.Validation;
+
 namespace XtremeIdiots.Portal.Repository.Api.V1.Services.Caching
 {
     /// <summary>
@@ -34,6 +36,14 @@ namespace XtremeIdiots.Portal.Repository.Api.V1.Services.Caching
 
         public async Task InvalidateServerSettingsAsync(Guid gameServerId, string ns, CancellationToken cancellationToken)
         {
+            // Normalize (e.g. legacy alias "serverList" -> canonical) so the tag matches the
+            // one used by CachingConfigurationReadService on the read path — otherwise an
+            // alias-scoped write would leave canonical-tagged reads stale until TTL.
+            if (!string.IsNullOrWhiteSpace(ns))
+            {
+                ns = NamespaceSchemaValidationRegistry.NormalizeNamespace(ns);
+            }
+
             var tag = RepositoryCacheKeys.SettingsServerTag(gameServerId, ns);
             await cache.RemoveByTagAsync(tag, cancellationToken).ConfigureAwait(false);
             metrics.RecordEviction(RepositoryCacheKeys.SurfaceSettings, tag);
@@ -41,6 +51,11 @@ namespace XtremeIdiots.Portal.Repository.Api.V1.Services.Caching
 
         public async Task InvalidateGlobalNamespaceAsync(string ns, CancellationToken cancellationToken)
         {
+            if (!string.IsNullOrWhiteSpace(ns))
+            {
+                ns = NamespaceSchemaValidationRegistry.NormalizeNamespace(ns);
+            }
+
             // Global tag removes the global-resolved entry; namespace tag also removes every
             // server-resolved entry for the namespace across all instances.
             var globalTag = RepositoryCacheKeys.SettingsGlobalTag(ns);

--- a/src/XtremeIdiots.Portal.Repository.Api.V1/Services/Caching/RepositoryCacheInvalidator.cs
+++ b/src/XtremeIdiots.Portal.Repository.Api.V1/Services/Caching/RepositoryCacheInvalidator.cs
@@ -1,0 +1,56 @@
+using MX.Caching.Abstractions;
+
+namespace XtremeIdiots.Portal.Repository.Api.V1.Services.Caching
+{
+    /// <summary>
+    /// Default <see cref="IRepositoryCacheInvalidator"/> — dispatches tag invalidations to
+    /// the shared <see cref="IMxCache"/> and records evictions on <see cref="RepositoryCacheMetrics"/>.
+    /// </summary>
+    public sealed class RepositoryCacheInvalidator : IRepositoryCacheInvalidator
+    {
+        private readonly IMxCache cache;
+        private readonly RepositoryCacheMetrics metrics;
+
+        public RepositoryCacheInvalidator(IMxCache cache, RepositoryCacheMetrics metrics)
+        {
+            ArgumentNullException.ThrowIfNull(cache);
+            ArgumentNullException.ThrowIfNull(metrics);
+            this.cache = cache;
+            this.metrics = metrics;
+        }
+
+        public async Task InvalidateGameServerAsync(Guid gameServerId, CancellationToken cancellationToken)
+        {
+            var tag = RepositoryCacheKeys.GameServerTag(gameServerId);
+            await cache.RemoveByTagAsync(tag, cancellationToken).ConfigureAwait(false);
+            metrics.RecordEviction(RepositoryCacheKeys.SurfaceGameServer, tag);
+        }
+
+        public async Task InvalidateDashboardAsync(CancellationToken cancellationToken)
+        {
+            await cache.RemoveByTagAsync(RepositoryCacheKeys.DashboardTag, cancellationToken).ConfigureAwait(false);
+            metrics.RecordEviction(RepositoryCacheKeys.SurfaceDashboard, RepositoryCacheKeys.DashboardTag);
+        }
+
+        public async Task InvalidateServerSettingsAsync(Guid gameServerId, string ns, CancellationToken cancellationToken)
+        {
+            var tag = RepositoryCacheKeys.SettingsServerTag(gameServerId, ns);
+            await cache.RemoveByTagAsync(tag, cancellationToken).ConfigureAwait(false);
+            metrics.RecordEviction(RepositoryCacheKeys.SurfaceSettings, tag);
+        }
+
+        public async Task InvalidateGlobalNamespaceAsync(string ns, CancellationToken cancellationToken)
+        {
+            // Global tag removes the global-resolved entry; namespace tag also removes every
+            // server-resolved entry for the namespace across all instances.
+            var globalTag = RepositoryCacheKeys.SettingsGlobalTag(ns);
+            var namespaceTag = RepositoryCacheKeys.SettingsNamespaceTag(ns);
+
+            await cache.RemoveByTagAsync(globalTag, cancellationToken).ConfigureAwait(false);
+            await cache.RemoveByTagAsync(namespaceTag, cancellationToken).ConfigureAwait(false);
+
+            metrics.RecordEviction(RepositoryCacheKeys.SurfaceSettings, globalTag);
+            metrics.RecordEviction(RepositoryCacheKeys.SurfaceSettings, namespaceTag);
+        }
+    }
+}

--- a/src/XtremeIdiots.Portal.Repository.Api.V1/Services/Caching/RepositoryCacheKeys.cs
+++ b/src/XtremeIdiots.Portal.Repository.Api.V1/Services/Caching/RepositoryCacheKeys.cs
@@ -1,0 +1,37 @@
+namespace XtremeIdiots.Portal.Repository.Api.V1.Services.Caching
+{
+    /// <summary>
+    /// Central definitions of cache keys and tags used by repository-side cache-aside decorators.
+    /// Keys and tags are stable strings so they survive process restarts and cross-instance tag
+    /// eviction through the shared Table Storage <see cref="MX.Caching.Abstractions.ICacheTagIndex"/>.
+    /// </summary>
+    public static class RepositoryCacheKeys
+    {
+        // --- Surfaces (used as metric labels) ---
+        public const string SurfaceGameServer = "gameserver";
+        public const string SurfaceDashboard = "dashboard";
+        public const string SurfaceSettings = "settings";
+
+        // --- Game server ---
+        public static string GameServerKey(Guid gameServerId) => $"gameserver:{gameServerId:N}";
+        public static string GameServerTag(Guid gameServerId) => $"gameserver:{gameServerId:N}";
+
+        // --- Dashboard aggregations ---
+        public static string DashboardKey(string metric, string window) => $"dashboard:{metric}:{window}";
+        public const string DashboardTag = "dashboard";
+
+        // --- Settings ---
+        public static string SettingsServerKey(Guid gameServerId, string ns) => $"settings:{gameServerId:N}:{ns}";
+        public static string SettingsGlobalKey(string ns) => $"settings:global:{ns}";
+
+        public static string SettingsServerTag(Guid gameServerId, string ns) => $"settings:server:{gameServerId:N}:{ns}";
+        public static string SettingsGlobalTag(string ns) => $"settings:global:{ns}";
+
+        /// <summary>
+        /// Cross-instance namespace tag applied to every server-resolved and global entry for a
+        /// namespace. A global-namespace mutation invalidates every server's resolved entry for
+        /// that namespace by evicting this tag.
+        /// </summary>
+        public static string SettingsNamespaceTag(string ns) => $"settings:ns:{ns}";
+    }
+}

--- a/src/XtremeIdiots.Portal.Repository.Api.V1/Services/Caching/RepositoryCacheMetrics.cs
+++ b/src/XtremeIdiots.Portal.Repository.Api.V1/Services/Caching/RepositoryCacheMetrics.cs
@@ -1,0 +1,43 @@
+using System.Diagnostics.Metrics;
+
+namespace XtremeIdiots.Portal.Repository.Api.V1.Services.Caching
+{
+    /// <summary>
+    /// Owns the <see cref="Meter"/> and instrument definitions used by the repository-side
+    /// cache-aside decorators. Metrics complement the built-in MX.Caching hit/miss/eviction
+    /// counters by attributing behaviour to the specific repository surface being served
+    /// (game server, dashboard, settings).
+    /// </summary>
+    public sealed class RepositoryCacheMetrics : IDisposable
+    {
+        /// <summary>Fully qualified meter name emitted to Application Insights / OpenTelemetry.</summary>
+        public const string MeterName = "XtremeIdiots.Portal.Repository.Api.V1.Cache";
+
+        private readonly Meter _meter;
+        private readonly Counter<long> _hits;
+        private readonly Counter<long> _misses;
+        private readonly Counter<long> _evictions;
+
+        public RepositoryCacheMetrics()
+        {
+            _meter = new Meter(MeterName, "1.0.0");
+            _hits = _meter.CreateCounter<long>("repository_cache_hits_total", unit: "count", description: "Server-side cache-aside hits, tagged by surface.");
+            _misses = _meter.CreateCounter<long>("repository_cache_misses_total", unit: "count", description: "Server-side cache-aside misses, tagged by surface.");
+            _evictions = _meter.CreateCounter<long>("repository_cache_evictions_total", unit: "count", description: "Server-side cache-aside eviction requests (by tag), tagged by surface.");
+        }
+
+        /// <summary>Records a cache hit for the given surface (e.g. <c>gameserver</c>, <c>dashboard</c>, <c>settings</c>).</summary>
+        public void RecordHit(string surface) => _hits.Add(1, new KeyValuePair<string, object?>("surface", surface));
+
+        /// <summary>Records a cache miss for the given surface.</summary>
+        public void RecordMiss(string surface) => _misses.Add(1, new KeyValuePair<string, object?>("surface", surface));
+
+        /// <summary>Records an eviction / tag-invalidation for the given surface and tag.</summary>
+        public void RecordEviction(string surface, string tag)
+            => _evictions.Add(1,
+                new KeyValuePair<string, object?>("surface", surface),
+                new KeyValuePair<string, object?>("tag", tag));
+
+        public void Dispose() => _meter.Dispose();
+    }
+}

--- a/src/XtremeIdiots.Portal.Repository.Api.V1/Services/ConfigurationReadService.cs
+++ b/src/XtremeIdiots.Portal.Repository.Api.V1/Services/ConfigurationReadService.cs
@@ -1,0 +1,100 @@
+using System.Net;
+
+using Microsoft.EntityFrameworkCore;
+
+using MX.Api.Abstractions;
+using MX.Api.Web.Extensions;
+
+using XtremeIdiots.Portal.Repository.Abstractions.Models.V1.Configurations;
+using XtremeIdiots.Portal.Repository.Api.V1.Mapping;
+using XtremeIdiots.Portal.Repository.Api.V1.Validation;
+using XtremeIdiots.Portal.Repository.DataLib;
+
+using ServerListContractConstants = XtremeIdiots.Portal.Settings.Contracts.V1.Contracts.ServerList.ServerListSettingsConstants;
+
+namespace XtremeIdiots.Portal.Repository.Api.V1.Services
+{
+    /// <summary>
+    /// Default (uncached) implementation of <see cref="IConfigurationReadService"/>. Behaviour
+    /// mirrors the pre-refactor <c>GameServerConfigurationsController.GetConfiguration</c> and
+    /// <c>GlobalConfigurationsController.GetConfiguration</c> paths, including the canonical/
+    /// legacy server-list namespace fallback.
+    /// </summary>
+    public sealed class ConfigurationReadService : IConfigurationReadService
+    {
+        private const string LegacyServerListNamespace = "serverList";
+        private static readonly string CanonicalServerListNamespaceLower = ServerListContractConstants.Namespace.ToLowerInvariant();
+        private static readonly string LegacyServerListNamespaceLower = LegacyServerListNamespace.ToLowerInvariant();
+
+        private readonly PortalDbContext context;
+
+        public ConfigurationReadService(PortalDbContext context)
+        {
+            ArgumentNullException.ThrowIfNull(context);
+            this.context = context;
+        }
+
+        public async Task<ApiResult<ConfigurationDto>> GetServerConfigurationAsync(Guid gameServerId, string ns, CancellationToken cancellationToken)
+        {
+            if (string.IsNullOrWhiteSpace(ns) || ns.Length > 128)
+            {
+                return new ApiResult<ConfigurationDto>(HttpStatusCode.BadRequest);
+            }
+
+            var config = await context.GameServerConfigurations
+                .AsNoTracking()
+                .FirstOrDefaultAsync(c => c.GameServerId == gameServerId && c.Namespace == ns, cancellationToken)
+                .ConfigureAwait(false);
+
+            if (config == null)
+            {
+                return new ApiResult<ConfigurationDto>(HttpStatusCode.NotFound);
+            }
+
+            return new ApiResponse<ConfigurationDto>(config.ToDto()).ToApiResult();
+        }
+
+        public async Task<ApiResult<ConfigurationDto>> GetGlobalConfigurationAsync(string ns, CancellationToken cancellationToken)
+        {
+            if (string.IsNullOrWhiteSpace(ns) || ns.Length > 128)
+            {
+                return new ApiResult<ConfigurationDto>(HttpStatusCode.BadRequest);
+            }
+
+            ns = NamespaceSchemaValidationRegistry.NormalizeNamespace(ns);
+
+            var isServerListNamespace = string.Equals(ns, ServerListContractConstants.Namespace, StringComparison.OrdinalIgnoreCase);
+
+            GlobalConfiguration? config;
+            if (isServerListNamespace)
+            {
+                var configs = await context.GlobalConfigurations
+                    .AsNoTracking()
+                    .Where(c =>
+                        c.Namespace.ToLower() == CanonicalServerListNamespaceLower ||
+                        c.Namespace.ToLower() == LegacyServerListNamespaceLower)
+                    .ToListAsync(cancellationToken).ConfigureAwait(false);
+
+                config = configs.FirstOrDefault(c => string.Equals(c.Namespace, ServerListContractConstants.Namespace, StringComparison.Ordinal))
+                    ?? configs.FirstOrDefault(c => string.Equals(c.Namespace, LegacyServerListNamespace, StringComparison.Ordinal))
+                    ?? configs
+                        .OrderByDescending(c => c.LastModifiedUtc)
+                        .ThenBy(c => c.Namespace, StringComparer.Ordinal)
+                        .FirstOrDefault();
+            }
+            else
+            {
+                config = await context.GlobalConfigurations
+                    .AsNoTracking()
+                    .FirstOrDefaultAsync(c => c.Namespace == ns, cancellationToken).ConfigureAwait(false);
+            }
+
+            if (config == null)
+            {
+                return new ApiResult<ConfigurationDto>(HttpStatusCode.NotFound);
+            }
+
+            return new ApiResponse<ConfigurationDto>(config.ToDto()).ToApiResult();
+        }
+    }
+}

--- a/src/XtremeIdiots.Portal.Repository.Api.V1/Services/DashboardService.cs
+++ b/src/XtremeIdiots.Portal.Repository.Api.V1/Services/DashboardService.cs
@@ -1,0 +1,249 @@
+using Microsoft.EntityFrameworkCore;
+
+using MX.Api.Abstractions;
+using MX.Api.Web.Extensions;
+
+using XtremeIdiots.Portal.Repository.Abstractions.Constants.V1;
+using XtremeIdiots.Portal.Repository.Abstractions.Models.V1.Dashboard;
+using XtremeIdiots.Portal.Repository.Api.V1.Extensions;
+using XtremeIdiots.Portal.Repository.Api.V1.TableStorage;
+using XtremeIdiots.Portal.Repository.DataLib;
+
+namespace XtremeIdiots.Portal.Repository.Api.V1.Services
+{
+    /// <summary>
+    /// Default (uncached) implementation of <see cref="IDashboardService"/>. Behaviour is a
+    /// faithful port of the pre-refactor <c>DashboardController</c> logic so the caching
+    /// decorator is transparent.
+    /// </summary>
+    public sealed class DashboardService : IDashboardService
+    {
+        private readonly PortalDbContext context;
+        private readonly ILiveStatusStore liveStatusStore;
+
+        public DashboardService(PortalDbContext context, ILiveStatusStore liveStatusStore)
+        {
+            ArgumentNullException.ThrowIfNull(context);
+            ArgumentNullException.ThrowIfNull(liveStatusStore);
+            this.context = context;
+            this.liveStatusStore = liveStatusStore;
+        }
+
+        public async Task<ApiResult<DashboardSummaryDto>> GetDashboardSummaryAsync(CancellationToken cancellationToken)
+        {
+            var oneDayAgo = DateTime.UtcNow.AddDays(-1);
+            var sevenDaysAgo = DateTime.UtcNow.AddDays(-7);
+
+            var totalServers = await context.GameServers
+                .AsNoTracking()
+                .CountAsync(gs => !gs.Deleted && gs.AgentEnabled, cancellationToken).ConfigureAwait(false);
+
+            var liveStatuses = await liveStatusStore.GetAllServerLiveStatusesAsync(cancellationToken).ConfigureAwait(false);
+            var onlineCount = liveStatuses.Count(s => s.IsOnline);
+            var totalPlayers = liveStatuses.Where(s => s.IsOnline).Sum(s => s.CurrentPlayers);
+
+            var unclaimedBanCount = await context.AdminActions
+                .AsNoTracking()
+                .CountAsync(a => a.Type == (int)AdminActionType.Ban && a.UserProfileId == null, cancellationToken).ConfigureAwait(false);
+
+            var openReportCount = await context.Reports
+                .AsNoTracking()
+                .CountAsync(r => !r.Closed, cancellationToken).ConfigureAwait(false);
+
+            var actions24h = await GetActionCountsSinceAsync(oneDayAgo, cancellationToken).ConfigureAwait(false);
+            var actions7d = await GetActionCountsSinceAsync(sevenDaysAgo, cancellationToken).ConfigureAwait(false);
+
+            var dto = new DashboardSummaryDto
+            {
+                TotalServers = totalServers,
+                OnlineServerCount = onlineCount,
+                OfflineServerCount = totalServers - onlineCount,
+                TotalPlayersOnline = totalPlayers,
+                UnclaimedBanCount = unclaimedBanCount,
+                OpenReportCount = openReportCount,
+                RecentActions24h = actions24h,
+                RecentActions7d = actions7d
+            };
+
+            return new ApiResponse<DashboardSummaryDto>(dto).ToApiResult();
+        }
+
+        public async Task<ApiResult<CollectionModel<AdminLeaderboardEntryDto>>> GetAdminLeaderboardAsync(int days, CancellationToken cancellationToken)
+        {
+            if (days <= 0)
+            {
+                days = 30;
+            }
+
+            var cutoff = DateTime.UtcNow.AddDays(-days);
+
+            var leaderboard = await context.AdminActions
+                .AsNoTracking()
+                .Where(a => a.Created >= cutoff && a.UserProfileId != null)
+                .GroupBy(a => a.UserProfileId!.Value)
+                .Select(g => new
+                {
+                    AdminId = g.Key,
+                    Bans = g.Count(a => a.Type == (int)AdminActionType.Ban),
+                    TempBans = g.Count(a => a.Type == (int)AdminActionType.TempBan),
+                    Kicks = g.Count(a => a.Type == (int)AdminActionType.Kick),
+                    Warnings = g.Count(a => a.Type == (int)AdminActionType.Warning),
+                    Observations = g.Count(a => a.Type == (int)AdminActionType.Observation),
+                    Total = g.Count()
+                })
+                .OrderByDescending(x => x.Total)
+                .ToListAsync(cancellationToken).ConfigureAwait(false);
+
+            var adminIds = leaderboard.Select(x => x.AdminId).ToList();
+            var adminProfiles = await context.UserProfiles
+                .AsNoTracking()
+                .Where(up => adminIds.Contains(up.UserProfileId))
+                .Select(up => new { up.UserProfileId, up.DisplayName })
+                .ToListAsync(cancellationToken).ConfigureAwait(false);
+
+            var profileLookup = adminProfiles.ToDictionary(x => x.UserProfileId, x => x.DisplayName ?? "Unknown");
+
+            var entries = leaderboard.Select(x => new AdminLeaderboardEntryDto
+            {
+                AdminId = x.AdminId,
+                DisplayName = profileLookup.GetValueOrDefault(x.AdminId, "Unknown"),
+                Bans = x.Bans,
+                TempBans = x.TempBans,
+                Kicks = x.Kicks,
+                Warnings = x.Warnings,
+                Observations = x.Observations,
+                Total = x.Total
+            }).ToList();
+
+            var result = new CollectionModel<AdminLeaderboardEntryDto> { Items = entries };
+
+            return new ApiResponse<CollectionModel<AdminLeaderboardEntryDto>>(result)
+            {
+                Pagination = new ApiPagination(entries.Count, entries.Count, 0, entries.Count)
+            }.ToApiResult();
+        }
+
+        public async Task<ApiResult<CollectionModel<ModerationTrendDataPointDto>>> GetModerationTrendAsync(int days, CancellationToken cancellationToken)
+        {
+            if (days <= 0)
+            {
+                days = 30;
+            }
+
+            var cutoff = DateTime.UtcNow.AddDays(-days);
+
+            var dailyCounts = await context.AdminActions
+                .AsNoTracking()
+                .Where(a => a.Created >= cutoff)
+                .GroupBy(a => a.Created.Date)
+                .Select(g => new
+                {
+                    Date = g.Key,
+                    Bans = g.Count(a => a.Type == (int)AdminActionType.Ban),
+                    TempBans = g.Count(a => a.Type == (int)AdminActionType.TempBan),
+                    Kicks = g.Count(a => a.Type == (int)AdminActionType.Kick),
+                    Warnings = g.Count(a => a.Type == (int)AdminActionType.Warning),
+                    Observations = g.Count(a => a.Type == (int)AdminActionType.Observation)
+                })
+                .OrderBy(x => x.Date)
+                .ToListAsync(cancellationToken).ConfigureAwait(false);
+
+            var entries = dailyCounts.Select(x => new ModerationTrendDataPointDto
+            {
+                Date = x.Date,
+                Bans = x.Bans,
+                TempBans = x.TempBans,
+                Kicks = x.Kicks,
+                Warnings = x.Warnings,
+                Observations = x.Observations
+            }).ToList();
+
+            var result = new CollectionModel<ModerationTrendDataPointDto> { Items = entries };
+
+            return new ApiResponse<CollectionModel<ModerationTrendDataPointDto>>(result)
+            {
+                Pagination = new ApiPagination(entries.Count, entries.Count, 0, entries.Count)
+            }.ToApiResult();
+        }
+
+        public async Task<ApiResult<ServerUtilizationCollectionDto>> GetServerUtilizationAsync(CancellationToken cancellationToken)
+        {
+            var cutoff = DateTime.UtcNow.AddHours(-24);
+
+            var servers = await context.GameServers
+                .AsNoTracking()
+                .Where(gs => !gs.Deleted && gs.AgentEnabled)
+                .Select(gs => new
+                {
+                    gs.GameServerId,
+                    gs.Title,
+                    gs.GameType,
+                })
+                .ToListAsync(cancellationToken).ConfigureAwait(false);
+
+            var liveStatuses = await liveStatusStore.GetAllServerLiveStatusesAsync(cancellationToken).ConfigureAwait(false);
+            var liveStatusLookup = liveStatuses.ToDictionary(s => s.ServerId);
+
+            var statsAggregates = await context.GameServerStats
+                .AsNoTracking()
+                .Where(s => s.Timestamp >= cutoff && s.GameServerId != null)
+                .GroupBy(s => s.GameServerId!.Value)
+                .Select(g => new
+                {
+                    ServerId = g.Key,
+                    AvgPlayers = g.Average(s => (double)s.PlayerCount),
+                    PeakPlayers = g.Max(s => s.PlayerCount)
+                })
+                .ToListAsync(cancellationToken).ConfigureAwait(false);
+
+            var statsLookup = statsAggregates.ToDictionary(x => x.ServerId);
+
+            var serverDtos = servers.Select(gs =>
+            {
+                var hasStats = statsLookup.TryGetValue(gs.GameServerId, out var stats);
+                var hasLiveStatus = liveStatusLookup.TryGetValue(gs.GameServerId, out var liveStatus);
+                var maxPlayers = hasLiveStatus ? liveStatus!.MaxPlayers : 0;
+                var avg = hasStats ? stats!.AvgPlayers : 0;
+
+                return new ServerUtilizationDto
+                {
+                    ServerId = gs.GameServerId,
+                    Title = hasLiveStatus && !string.IsNullOrWhiteSpace(liveStatus!.Title) ? liveStatus.Title : gs.Title,
+                    GameType = gs.GameType.ToGameType().ToString(),
+                    AvgPlayers = Math.Round(avg, 1),
+                    PeakPlayers = hasStats ? stats!.PeakPlayers : 0,
+                    MaxPlayers = maxPlayers,
+                    Utilization = maxPlayers > 0 ? Math.Round(avg / maxPlayers, 3) : 0
+                };
+            }).ToList();
+
+            var dto = new ServerUtilizationCollectionDto
+            {
+                Servers = serverDtos,
+                TotalAvgPlayers = Math.Round(serverDtos.Sum(s => s.AvgPlayers), 1),
+                TotalPeakPlayers = serverDtos.Sum(s => s.PeakPlayers)
+            };
+
+            return new ApiResponse<ServerUtilizationCollectionDto>(dto).ToApiResult();
+        }
+
+        private async Task<AdminActionCountsDto> GetActionCountsSinceAsync(DateTime since, CancellationToken cancellationToken)
+        {
+            var counts = await context.AdminActions
+                .AsNoTracking()
+                .Where(a => a.Created >= since)
+                .GroupBy(a => a.Type)
+                .Select(g => new { Type = g.Key, Count = g.Count() })
+                .ToListAsync(cancellationToken).ConfigureAwait(false);
+
+            return new AdminActionCountsDto
+            {
+                Bans = counts.FirstOrDefault(c => c.Type == (int)AdminActionType.Ban)?.Count ?? 0,
+                TempBans = counts.FirstOrDefault(c => c.Type == (int)AdminActionType.TempBan)?.Count ?? 0,
+                Kicks = counts.FirstOrDefault(c => c.Type == (int)AdminActionType.Kick)?.Count ?? 0,
+                Warnings = counts.FirstOrDefault(c => c.Type == (int)AdminActionType.Warning)?.Count ?? 0,
+                Observations = counts.FirstOrDefault(c => c.Type == (int)AdminActionType.Observation)?.Count ?? 0
+            };
+        }
+    }
+}

--- a/src/XtremeIdiots.Portal.Repository.Api.V1/Services/GameServerReadService.cs
+++ b/src/XtremeIdiots.Portal.Repository.Api.V1/Services/GameServerReadService.cs
@@ -1,0 +1,45 @@
+using System.Net;
+
+using Microsoft.EntityFrameworkCore;
+
+using MX.Api.Abstractions;
+using MX.Api.Web.Extensions;
+
+using XtremeIdiots.Portal.Repository.Abstractions.Models.V1.GameServers;
+using XtremeIdiots.Portal.Repository.Api.V1.Mapping;
+using XtremeIdiots.Portal.Repository.DataLib;
+
+namespace XtremeIdiots.Portal.Repository.Api.V1.Services
+{
+    /// <summary>
+    /// Default (uncached) implementation of <see cref="IGameServerReadService"/> — hits SQL directly.
+    /// Behaviour mirrors the pre-refactor <c>GameServersController.GetGameServer</c> path so wrapping
+    /// in a caching decorator is transparent to callers.
+    /// </summary>
+    public sealed class GameServerReadService : IGameServerReadService
+    {
+        private readonly PortalDbContext context;
+
+        public GameServerReadService(PortalDbContext context)
+        {
+            ArgumentNullException.ThrowIfNull(context);
+            this.context = context;
+        }
+
+        public async Task<ApiResult<GameServerDto>> GetGameServerAsync(Guid gameServerId, CancellationToken cancellationToken)
+        {
+            var gameServer = await context.GameServers
+                .Include(gs => gs.BanFileMonitors)
+                .AsNoTracking()
+                .FirstOrDefaultAsync(gs => gs.GameServerId == gameServerId && !gs.Deleted, cancellationToken)
+                .ConfigureAwait(false);
+
+            if (gameServer == null)
+            {
+                return new ApiResult<GameServerDto>(HttpStatusCode.NotFound);
+            }
+
+            return new ApiResponse<GameServerDto>(gameServer.ToDto()).ToApiResult();
+        }
+    }
+}

--- a/src/XtremeIdiots.Portal.Repository.Api.V1/Services/IConfigurationReadService.cs
+++ b/src/XtremeIdiots.Portal.Repository.Api.V1/Services/IConfigurationReadService.cs
@@ -1,0 +1,28 @@
+using MX.Api.Abstractions;
+
+using XtremeIdiots.Portal.Repository.Abstractions.Models.V1.Configurations;
+
+namespace XtremeIdiots.Portal.Repository.Api.V1.Services
+{
+    /// <summary>
+    /// Repository-side seam for reading resolved configuration documents. Extracted so the
+    /// per-server and global reads can be layered with caching decorators; mutation-side
+    /// controllers still write directly to <see cref="DataLib.PortalDbContext"/> and evict
+    /// via <see cref="Caching.IRepositoryCacheInvalidator"/>.
+    /// </summary>
+    public interface IConfigurationReadService
+    {
+        /// <summary>
+        /// Returns the per-server configuration document for <paramref name="ns"/>, or
+        /// <c>NotFound</c> when no row exists. Also returns <c>NotFound</c> when the game
+        /// server itself does not exist.
+        /// </summary>
+        Task<ApiResult<ConfigurationDto>> GetServerConfigurationAsync(Guid gameServerId, string ns, CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Returns the global configuration document for <paramref name="ns"/> preserving the
+        /// canonical/legacy server-list namespace compatibility behaviour.
+        /// </summary>
+        Task<ApiResult<ConfigurationDto>> GetGlobalConfigurationAsync(string ns, CancellationToken cancellationToken);
+    }
+}

--- a/src/XtremeIdiots.Portal.Repository.Api.V1/Services/IDashboardService.cs
+++ b/src/XtremeIdiots.Portal.Repository.Api.V1/Services/IDashboardService.cs
@@ -1,0 +1,18 @@
+using MX.Api.Abstractions;
+
+using XtremeIdiots.Portal.Repository.Abstractions.Models.V1.Dashboard;
+
+namespace XtremeIdiots.Portal.Repository.Api.V1.Services
+{
+    /// <summary>
+    /// Server-side seam for dashboard aggregations, extracted from
+    /// <c>DashboardController</c> so caching can be layered as a decorator.
+    /// </summary>
+    public interface IDashboardService
+    {
+        Task<ApiResult<DashboardSummaryDto>> GetDashboardSummaryAsync(CancellationToken cancellationToken);
+        Task<ApiResult<CollectionModel<AdminLeaderboardEntryDto>>> GetAdminLeaderboardAsync(int days, CancellationToken cancellationToken);
+        Task<ApiResult<CollectionModel<ModerationTrendDataPointDto>>> GetModerationTrendAsync(int days, CancellationToken cancellationToken);
+        Task<ApiResult<ServerUtilizationCollectionDto>> GetServerUtilizationAsync(CancellationToken cancellationToken);
+    }
+}

--- a/src/XtremeIdiots.Portal.Repository.Api.V1/Services/IGameServerReadService.cs
+++ b/src/XtremeIdiots.Portal.Repository.Api.V1/Services/IGameServerReadService.cs
@@ -1,0 +1,15 @@
+using MX.Api.Abstractions;
+
+using XtremeIdiots.Portal.Repository.Abstractions.Models.V1.GameServers;
+
+namespace XtremeIdiots.Portal.Repository.Api.V1.Services
+{
+    /// <summary>
+    /// Repository-side seam for reading game server rows. Extracted from the controller
+    /// so caching can be layered as a decorator without controller-level cache hacks.
+    /// </summary>
+    public interface IGameServerReadService
+    {
+        Task<ApiResult<GameServerDto>> GetGameServerAsync(Guid gameServerId, CancellationToken cancellationToken);
+    }
+}

--- a/src/XtremeIdiots.Portal.Repository.Api.V1/Services/ServiceCollectionExtensions.cs
+++ b/src/XtremeIdiots.Portal.Repository.Api.V1/Services/ServiceCollectionExtensions.cs
@@ -1,0 +1,65 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+
+using XtremeIdiots.Portal.Repository.Api.V1.Services.Caching;
+
+namespace XtremeIdiots.Portal.Repository.Api.V1.Services
+{
+    /// <summary>
+    /// DI wire-up for repository-side service seams and their caching decorators.
+    /// </summary>
+    public static class ServiceCollectionExtensions
+    {
+        /// <summary>
+        /// Registers the repository-side read services and, when <paramref name="enableCaching"/>
+        /// is true, their <see cref="MX.Caching.Abstractions.IMxCache"/>-backed decorators.
+        /// The <see cref="RepositoryCacheMetrics"/> singleton is always registered so the
+        /// invalidator and decorators can share a single <see cref="System.Diagnostics.Metrics.Meter"/>.
+        /// </summary>
+        public static IServiceCollection AddRepositoryReadServices(this IServiceCollection services, bool enableCaching)
+        {
+            ArgumentNullException.ThrowIfNull(services);
+
+            services.TryAddSingleton<RepositoryCacheMetrics>();
+
+            if (enableCaching)
+            {
+                // Concrete uncached implementations remain scoped (DbContext lifetime).
+                services.AddScoped<GameServerReadService>();
+                services.AddScoped<DashboardService>();
+                services.AddScoped<ConfigurationReadService>();
+
+                // Public seams resolve to the caching decorator, which delegates into the
+                // concrete implementations above on miss.
+                services.AddScoped<IGameServerReadService>(sp =>
+                    new CachingGameServerReadService(
+                        sp.GetRequiredService<GameServerReadService>(),
+                        sp.GetRequiredService<MX.Caching.Abstractions.IMxCache>(),
+                        sp.GetRequiredService<RepositoryCacheMetrics>()));
+
+                services.AddScoped<IDashboardService>(sp =>
+                    new CachingDashboardService(
+                        sp.GetRequiredService<DashboardService>(),
+                        sp.GetRequiredService<MX.Caching.Abstractions.IMxCache>(),
+                        sp.GetRequiredService<RepositoryCacheMetrics>()));
+
+                services.AddScoped<IConfigurationReadService>(sp =>
+                    new CachingConfigurationReadService(
+                        sp.GetRequiredService<ConfigurationReadService>(),
+                        sp.GetRequiredService<MX.Caching.Abstractions.IMxCache>(),
+                        sp.GetRequiredService<RepositoryCacheMetrics>()));
+
+                services.AddScoped<IRepositoryCacheInvalidator, RepositoryCacheInvalidator>();
+            }
+            else
+            {
+                services.AddScoped<IGameServerReadService, GameServerReadService>();
+                services.AddScoped<IDashboardService, DashboardService>();
+                services.AddScoped<IConfigurationReadService, ConfigurationReadService>();
+                services.AddScoped<IRepositoryCacheInvalidator, NoOpRepositoryCacheInvalidator>();
+            }
+
+            return services;
+        }
+    }
+}

--- a/src/XtremeIdiots.Portal.Repository.Api.V1/XtremeIdiots.Portal.Repository.Api.V1.csproj
+++ b/src/XtremeIdiots.Portal.Repository.Api.V1/XtremeIdiots.Portal.Repository.Api.V1.csproj
@@ -24,8 +24,11 @@
     <PackageReference Include="Microsoft.Data.SqlClient" Version="7.0.2" />
     <PackageReference Include="Microsoft.Data.SqlClient.Extensions.Azure" Version="7.0.2" />
     <PackageReference Include="Microsoft.Identity.Web" Version="4.13.2" />
-    <PackageReference Include="MX.Api.Abstractions" Version="2.3.67" />
-    <PackageReference Include="MX.Api.Web.Extensions" Version="2.3.67" />
+    <PackageReference Include="MX.Api.Abstractions" Version="2.3.76" />
+    <PackageReference Include="MX.Api.Web.Extensions" Version="2.3.76" />
+    <PackageReference Include="MX.Caching" Version="0.1.5" />
+    <PackageReference Include="MX.Caching.Abstractions" Version="0.1.5" />
+    <PackageReference Include="MX.Caching.TableStorage" Version="0.1.5" />
     <PackageReference Include="MX.Observability.ApplicationInsights.AspNetCore" Version="1.1.24" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageReference Include="Scalar.AspNetCore" Version="2.16.16" />

--- a/src/XtremeIdiots.Portal.Repository.Api.V2/Controllers/V2/ApiInfoController.cs
+++ b/src/XtremeIdiots.Portal.Repository.Api.V2/Controllers/V2/ApiInfoController.cs
@@ -2,6 +2,7 @@ using System.Reflection;
 using Asp.Versioning;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using XtremeIdiots.Portal.Repository.Api.V2.Extensions;
 using XtremeIdiots.Portal.RepositoryWebApi.Models;
 
 namespace XtremeIdiots.Portal.RepositoryWebApi.Controllers.V2;
@@ -10,6 +11,7 @@ namespace XtremeIdiots.Portal.RepositoryWebApi.Controllers.V2;
 [AllowAnonymous]
 [ApiVersion("2.0")]
 [Route("v{version:apiVersion}/info")]
+[NoStoreCache]
 public class ApiInfoController : ControllerBase
 {
     [HttpGet]

--- a/src/XtremeIdiots.Portal.Repository.Api.V2/Controllers/V2/HealthController.cs
+++ b/src/XtremeIdiots.Portal.Repository.Api.V2/Controllers/V2/HealthController.cs
@@ -2,6 +2,7 @@ using Asp.Versioning;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
+using XtremeIdiots.Portal.Repository.Api.V2.Extensions;
 
 namespace XtremeIdiots.Portal.RepositoryWebApi.Controllers.V2;
 
@@ -9,6 +10,7 @@ namespace XtremeIdiots.Portal.RepositoryWebApi.Controllers.V2;
 [AllowAnonymous]
 [ApiVersion("2.0")]
 [Route("v{version:apiVersion}/health")]
+[NoStoreCache]
 public class HealthController : ControllerBase
 {
     private readonly HealthCheckService _healthCheckService;

--- a/src/XtremeIdiots.Portal.Repository.Api.V2/Extensions/NoStoreCacheAttribute.cs
+++ b/src/XtremeIdiots.Portal.Repository.Api.V2/Extensions/NoStoreCacheAttribute.cs
@@ -1,0 +1,24 @@
+using Microsoft.AspNetCore.Mvc.Filters;
+
+namespace XtremeIdiots.Portal.Repository.Api.V2.Extensions
+{
+    /// <summary>
+    /// Action filter that stamps <c>Cache-Control: no-store, no-cache</c>, <c>Pragma: no-cache</c>
+    /// and <c>Expires: 0</c> on the response. Applied to endpoints that must never be served
+    /// from any cache — most importantly <c>/info</c> (deploy version verification) and
+    /// <c>/health/*</c> (live status).
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Method, AllowMultiple = false, Inherited = true)]
+    public sealed class NoStoreCacheAttribute : Attribute, IActionFilter
+    {
+        public void OnActionExecuting(ActionExecutingContext context) { }
+
+        public void OnActionExecuted(ActionExecutedContext context)
+        {
+            var headers = context.HttpContext.Response.Headers;
+            headers.CacheControl = "no-store, no-cache, must-revalidate, max-age=0";
+            headers.Pragma = "no-cache";
+            headers.Expires = "0";
+        }
+    }
+}

--- a/src/XtremeIdiots.Portal.Repository.Api.V2/XtremeIdiots.Portal.Repository.Api.V2.csproj
+++ b/src/XtremeIdiots.Portal.Repository.Api.V2/XtremeIdiots.Portal.Repository.Api.V2.csproj
@@ -23,8 +23,8 @@
     <PackageReference Include="Microsoft.Data.SqlClient" Version="7.0.2" />
     <PackageReference Include="Microsoft.Data.SqlClient.Extensions.Azure" Version="7.0.2" />
     <PackageReference Include="Microsoft.Identity.Web" Version="4.13.2" />
-    <PackageReference Include="MX.Api.Abstractions" Version="2.3.67" />
-    <PackageReference Include="MX.Api.Web.Extensions" Version="2.3.67" />
+    <PackageReference Include="MX.Api.Abstractions" Version="2.3.76" />
+    <PackageReference Include="MX.Api.Web.Extensions" Version="2.3.76" />
     <PackageReference Include="MX.Observability.ApplicationInsights.AspNetCore" Version="1.1.24" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageReference Include="Scalar.AspNetCore" Version="2.16.16" />

--- a/terraform/locals.tf
+++ b/terraform/locals.tf
@@ -39,6 +39,15 @@ locals {
   app_service_plan             = data.terraform_remote_state.portal_core.outputs.app_service_plans["apps"]
   sql_server                   = data.terraform_remote_state.portal_core.outputs.sql_server
 
+  # Shared cache Storage Account from portal-core. Shape (as of the portal-core
+  # coordination update): { id, name, table_endpoint }. Consumed with try() so
+  # `terraform plan` succeeds against portal-core state versions that have not
+  # yet published the output; the API host falls back to legacy per-repository
+  # Table Storage in that case.
+  cache_storage                       = try(data.terraform_remote_state.portal_core.outputs.cache_storage, null)
+  shared_cache_storage_table_endpoint = try(local.cache_storage.table_endpoint, null)
+  shared_cache_storage_id             = try(local.cache_storage.id, null)
+
   # Local Resource Naming
   web_app_name_v1            = "app-portal-repo-${var.environment}-${var.location}-v1-${random_id.environment_id.hex}"
   web_app_name_v2            = "app-portal-repo-${var.environment}-${var.location}-v2-${random_id.environment_id.hex}"

--- a/terraform/storage_account.tf
+++ b/terraform/storage_account.tf
@@ -62,11 +62,11 @@ resource "azurerm_storage_account" "table_storage" {
 }
 
 resource "azurerm_storage_table" "live_status" {
-  name                 = "GameServerLiveStatus"
-  storage_account_name = azurerm_storage_account.table_storage.name
+  name               = "GameServerLiveStatus"
+  storage_account_id = azurerm_storage_account.table_storage.id
 }
 
 resource "azurerm_storage_table" "live_players" {
-  name                 = "GameServerLivePlayers"
-  storage_account_name = azurerm_storage_account.table_storage.name
+  name               = "GameServerLivePlayers"
+  storage_account_id = azurerm_storage_account.table_storage.id
 }

--- a/terraform/web_app_v1.tf
+++ b/terraform/web_app_v1.tf
@@ -53,9 +53,11 @@ resource "azurerm_linux_web_app" "app_v1" {
     # `ILiveStatusStore` and configures MX.Caching to use TableStorage as the
     # cross-instance backend + tag index. When absent the host falls back to
     # in-memory caching and the legacy Table Storage account (dev / rollback).
-    "shared_cache_storage_table_endpoint" = local.shared_cache_storage_table_endpoint
+    # coalesce() is used because app_settings values must be strings (not null)
+    # even when the upstream `cache_storage` output is not yet published.
+    "shared_cache_storage_table_endpoint" = coalesce(local.shared_cache_storage_table_endpoint, "")
     "MxCaching__Backend"                  = local.shared_cache_storage_table_endpoint != null ? "TableStorage" : "InMemory"
-    "MxCaching__TableStorage__Endpoint"   = local.shared_cache_storage_table_endpoint
+    "MxCaching__TableStorage__Endpoint"   = coalesce(local.shared_cache_storage_table_endpoint, "")
     "MxCaching__TableStorage__TableName"  = "RepositoryCache"
 
     // https://learn.microsoft.com/en-us/azure/azure-monitor/profiler/profiler-azure-functions#app-settings-for-enabling-profiler

--- a/terraform/web_app_v1.tf
+++ b/terraform/web_app_v1.tf
@@ -48,6 +48,16 @@ resource "azurerm_linux_web_app" "app_v1" {
     "appdata_storage_blob_endpoint"  = azurerm_storage_account.web_api_storage.primary_blob_endpoint
     "appdata_storage_table_endpoint" = azurerm_storage_account.table_storage.primary_table_endpoint
 
+    # Shared cache Table endpoint from portal-core. When present the API host
+    # prefers this over the legacy `appdata_storage_table_endpoint` for
+    # `ILiveStatusStore` and configures MX.Caching to use TableStorage as the
+    # cross-instance backend + tag index. When absent the host falls back to
+    # in-memory caching and the legacy Table Storage account (dev / rollback).
+    "shared_cache_storage_table_endpoint" = local.shared_cache_storage_table_endpoint
+    "MxCaching__Backend"                  = local.shared_cache_storage_table_endpoint != null ? "TableStorage" : "InMemory"
+    "MxCaching__TableStorage__Endpoint"   = local.shared_cache_storage_table_endpoint
+    "MxCaching__TableStorage__TableName"  = "RepositoryCache"
+
     // https://learn.microsoft.com/en-us/azure/azure-monitor/profiler/profiler-azure-functions#app-settings-for-enabling-profiler
     "APPINSIGHTS_PROFILERFEATURE_VERSION"  = "1.0.0"
     "DiagnosticServices_EXTENSION_VERSION" = "~3"


### PR DESCRIPTION
## Summary

Implements the portal-repository-owned scope of the Phase 2 Part 1 caching work package: bumps MX.Api.Client to 2.3.76, registers V1/V2 client-side default cache policies per sub-API, introduces server-side cache-aside decorators (game server / dashboard / configurations) with cross-instance tag eviction via `IMxCache`, adds `Cache-Control: no-store` on info/health, repoints `ILiveStatusStore` at the shared Table Storage cache endpoint from portal-core with MI-safe table creation, wires the Terraform slice, and extends the connected-players published contract with server-side search and typed ordering.

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected) — see Consumer impact
- [ ] Bug fix
- [ ] Refactor / hardening (no behavioural change)
- [ ] Docs only
- [ ] Chore / dependency bump

## What changed

### Package bumps
- `MX.Api.Client`, `MX.Api.Abstractions`, `MX.Api.Web.Extensions` → `2.3.76` across the two hosts, Abstractions.V1/V2, Client.V1/V2, and Client.Testing.
- Add `MX.Caching` `0.1.5` + `MX.Caching.TableStorage` + `MX.Caching.Testing` where needed.

### Client library defaults (V1 + V2)
Registers `AddDefaultCachePolicies<TSubApi>(…)` **per sub-API interface** (aligned with each `AddTypedApiClient<TSubApi>`) so `DefaultCachePolicies<TSubApi>` resolves correctly:

- **V1** — `IGameServersApi.GetGameServer(id)` / `GetGameServers(...)` cached 60s; `IMapsApi.GetMap` overloads + `GetMaps` cached 10 min (invocation expressions disambiguate overloads); `IUserProfileApi`, `IApiInfoApi`, `IApiHealthApi` and all mutations `NotCached`.
- **V2** — `IApiInfoApi` / `IApiHealthApi` `NotCached`. V2 currently exposes only info/health; no resource surfaces to cache.

New tests: `RepositoryApiCacheDefaultsTests` on both client test projects prove effective policy set.

### Server-side cache-aside (below controllers)
Introduces clean service seams and caching decorators — controllers no longer receive `IMxCache` directly:

- `GameServerReadService` / `CachingGameServerReadService` — 60s, tag `gameserver:{id}`.
- `DashboardService` / `CachingDashboardService` — 60–120s, tags `dashboard:{metric}:{window}` (dashboard summary, admin leaderboard 30d, moderation trend 30d, server utilization).
- `ConfigurationReadService` / `CachingConfigurationReadService` — 5 min, tags `settings:server:{gameServerId}:{ns}`, `settings:global:{ns}`, `settings:ns:{ns}`. Legacy namespace aliases (e.g. `serverList`) are normalised before key/tag computation so alias-scoped entries evict on canonical-scoped writes.
- `RepositoryCacheInvalidator` — cross-instance eviction via `IMxCache.RemoveByTagAsync` on successful create/update/delete/bulk mutations.
- `RepositoryCacheMetrics` — `System.Diagnostics.Metrics.Meter` counters for hit / miss / eviction.

### Never-cache guards
- New `NoStoreCacheAttribute` (V1 + V2) applied to `ApiInfoController` and `HealthController`, stamping `Cache-Control: no-store`, `Pragma: no-cache`, `Expires: 0`. Focused unit tests on both hosts. Deployment version-verification poll behaviour preserved.

### Shared Table Storage cache
- `Program.cs` now prefers `shared_cache_storage_table_endpoint` (portal-core) for `ILiveStatusStore` and MX.Caching, falling back to legacy `appdata_storage_table_endpoint`. Managed identity only; no keys/SAS.
- MI-safe `CreateTableIfNotExistsAsync` for `GameServerLiveStatus` / `GameServerLivePlayers` at startup (portal-core intentionally does not pre-create tables; MX.Caching self-creates its own configured table).
- Adds `AddMxCaching(Configuration)` wiring.

### Terraform slice
- `locals.tf` consumes `data.terraform_remote_state.portal_core.outputs.cache_storage` via `try(...)` — graceful when the upstream output is not yet published.
- `web_app_v1.tf` adds V1 app settings: `shared_cache_storage_table_endpoint`, `MxCaching__Backend` (`TableStorage` when the shared endpoint is present, else `InMemory`), `MxCaching__TableStorage__Endpoint`, `MxCaching__TableStorage__TableName=RepositoryCache`.
- Repository-local `table_storage` + LiveStatus tables + local role assignment retained for safe cutover / rollback; removal deferred until every environment’s portal-core state exposes `cache_storage`.

### Connected players — published contract change
- New `ConnectedPlayersOrder` enum (GameType, Username, LinkMethod, IsActive, LinkedAtUtc, UnlinkedAtUtc × Asc/Desc; default `LinkedAtUtcDesc`).
- `IConnectedPlayersApi.GetConnectedPlayers` gains `search` (matches Username, PlayerId, UserProfileId, LinkMethod, GameType) and `order` parameters.
- Controller filters/orders/pages in SQL; response includes `filteredCount` distinct from unfiltered `totalCount` (DataTables semantics).
- Client.V1 query serialization, `FakeConnectedPlayersApi`, and tests updated.

## Consumer impact

- **`XtremeIdiots.Portal.Repository.Abstractions.V1`** — **breaking**: `IConnectedPlayersApi.GetConnectedPlayers` signature adds `search` + `order`; response paged shape adds `filteredCount`. New public `ConnectedPlayersOrder` enum.
- **`XtremeIdiots.Portal.Repository.Api.Client.V1`** — matches Abstractions.V1 above; also gains client-side default cache policies via `UseLibraryDefaults()`. Consumers using `WithoutLibraryDefaults()` see no behavioural change.
- **`XtremeIdiots.Portal.Repository.Api.Client.V2`** — new default cache policies for info/health only.
- **`XtremeIdiots.Portal.Repository.Api.Client.Testing`** — `FakeConnectedPlayersApi` honours the new parameters.
- **portal-web** must update its `GetConnectedPlayers` call sites to pass `search` / `order` and read `filteredCount`.
- **portal-core** dependency: `cache_storage` output (shape `{ id, name, table_endpoint }`) is consumed via `try(...)`. When absent, the host and MxCaching fall back to legacy Table Storage / in-memory — rollback-safe.

## Validation evidence

```
dotnet build src\XtremeIdiots.Portal.Repository.sln
  Build succeeded. 0 Warning(s) 0 Error(s)

dotnet test src\XtremeIdiots.Portal.Repository.sln --no-build --nologo --filter "FullyQualifiedName!~IntegrationTests"
  Api.Client.Tests.V1        46 passed × 2 TFMs
  Api.Client.Tests.V2        14 passed × 2 TFMs
  Api.Client.Testing.Tests   72 passed × 2 TFMs
  Api.Tests.V1              446 passed, 10 skipped × 2 TFMs
  Api.Tests.V2                9 passed × 2 TFMs
  Settings.Contracts.V1      44 passed × 2 TFMs
  TOTAL: 631 passed / TFM, 0 failed

dotnet format src\XtremeIdiots.Portal.Repository.sln --verify-no-changes
  clean (exit 0)

terraform -chdir=terraform fmt -check -recursive
  clean (exit 0)

terraform -chdir=terraform validate
  FAILS — pre-existing azurerm v5 schema drift on storage_account.tf
  (azurerm_storage_table.storage_account_name deprecated). Untouched by this
  diff and unrelated to the caching scope.

terraform init/plan against Azure
  not attempted — no dev backend credentials available in this environment.
```

Code-review sub-agent run: one Medium finding (config decorator did not normalise legacy namespace aliases → alias-scoped entries lingered until TTL). Fixed in-scope with a regression test that proves canonical-scoped invalidation evicts alias reads.

## Risk and rollout

- **Blast radius** — V1 API host (game servers / dashboard / configurations paths) + LiveStatus wiring + published Client.V1 contract for connected players.
- **Auto-deploy** — via existing dev/prd workflows; deploy verification polls `/v1.0/info` and `/v2.0/info` which now carry `no-store` (verified with unit tests).
- **Manual steps post-merge** — portal-web must be updated to the new `GetConnectedPlayers` signature before its next release. Once every environment's portal-core state exposes `cache_storage`, we can drop the repo-local Table Storage + role assignment in a follow-up.
- **Rollback** — Terraform `try(...)` and Program.cs fallback mean absence of the portal-core output degrades gracefully to legacy Table Storage / in-memory; reverting this PR restores prior behaviour without data loss (LiveStatus tables live in shared storage but the schema is unchanged).

## Known limitations / upstream dependencies

- **MX.Api.Client 2.3.76** does not support parameter-templated dynamic tags on client-side policies — literal `gameserver:{id}` at the client layer is impossible. Instance-scoped tagging is handled by the server-side decorator where the actual GUID is bound at runtime.
- **portal-core `cache_storage` output** — consumed via `try(...)`; behaviour degrades gracefully if not yet published in a given environment.
- **Pre-existing terraform validate failure** on `azurerm_storage_table.storage_account_name` (azurerm v5) is untouched by this PR and out of scope for the caching work.

## Agent attestation

- [x] Followed AGENTS.md and repository copilot instructions.
- [x] Preserved API envelope (`ApiResponse` / `CollectionResult`), routing, managed identity, settings validation, and compatibility shims.
- [x] Did not edit generated DataLib or the Database schema.
- [x] Did not introduce secrets or connection strings; managed identity only.
- [x] Did not add controller-level cache hacks, broad catches, or silent fallbacks.
- [x] Ran `dotnet build`, unit tests, `dotnet format --verify-no-changes`, `terraform fmt -check -recursive` — all clean.
- [x] Ran the code-review sub-agent; the Medium finding was resolved with a regression test.
- [x] Published contract changes (Abstractions.V1 / Client.V1 / Client.Testing) are documented under Consumer impact.
