### PR TITLE
feat: cache correctness hardening - serialization fix, Tiered policies, key versioning, collection/map caching, resilience, MX.Caching 0.1.6

### DIFF
--- a/src/XtremeIdiots.Portal.Repository.Api.Tests.V1/Controllers/V1/MapsControllerTests.cs
+++ b/src/XtremeIdiots.Portal.Repository.Api.Tests.V1/Controllers/V1/MapsControllerTests.cs
@@ -6,6 +6,8 @@ using XtremeIdiots.Portal.Repository.Abstractions.Constants.V1;
 using XtremeIdiots.Portal.Repository.Abstractions.Interfaces.V1;
 using XtremeIdiots.Portal.Repository.Abstractions.Models.V1.Maps;
 using XtremeIdiots.Portal.Repository.Api.Tests.V1.TestHelpers;
+using XtremeIdiots.Portal.Repository.Api.V1.Services;
+using XtremeIdiots.Portal.Repository.Api.V1.Services.Caching;
 using XtremeIdiots.Portal.Repository.DataLib;
 using XtremeIdiots.Portal.RepositoryWebApi.Controllers.V1;
 
@@ -16,7 +18,9 @@ public class MapsControllerTests
     private MapsController CreateController(PortalDbContext context)
     {
         var logger = new Mock<ILogger<MapsController>>();
-        return new MapsController(context, logger.Object);
+        var mapReadService = new MapReadService(context);
+        var cacheInvalidator = new NoOpRepositoryCacheInvalidator();
+        return new MapsController(context, logger.Object, mapReadService, cacheInvalidator);
     }
 
     [Fact]

--- a/src/XtremeIdiots.Portal.Repository.Api.Tests.V1/Services/Caching/CachingHardeningTests.cs
+++ b/src/XtremeIdiots.Portal.Repository.Api.Tests.V1/Services/Caching/CachingHardeningTests.cs
@@ -1,0 +1,389 @@
+using System;
+using System.Buffers;
+using System.Net;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Microsoft.Extensions.Logging.Abstractions;
+
+using MX.Api.Abstractions;
+using MX.Caching.Abstractions;
+using MX.Caching.Testing;
+
+using Newtonsoft.Json;
+
+using XtremeIdiots.Portal.Repository.Abstractions.Constants.V1;
+using XtremeIdiots.Portal.Repository.Abstractions.Models.V1.Configurations;
+using XtremeIdiots.Portal.Repository.Abstractions.Models.V1.GameServers;
+using XtremeIdiots.Portal.Repository.Abstractions.Models.V1.Maps;
+using XtremeIdiots.Portal.Repository.Api.V1.Serialization;
+using XtremeIdiots.Portal.Repository.Api.V1.Services;
+using XtremeIdiots.Portal.Repository.Api.V1.Services.Caching;
+
+using Xunit;
+
+namespace XtremeIdiots.Portal.Repository.Api.Tests.V1.Services.Caching
+{
+    /// <summary>
+    /// Phase A and C hardening tests: serialisation round-trips, key versioning,
+    /// collection caching, map caching, and cache resilience (fail-open).
+    /// </summary>
+    public class CachingHardeningTests
+    {
+        private static RepositoryCacheMetrics CreateMetrics() => new();
+
+        private static ApiResult<T> Ok<T>(T value) => new(HttpStatusCode.OK, new ApiResponse<T>(value));
+
+        // -----------------------------------------------------------------------
+        // A1 — Serialization round-trip
+        // -----------------------------------------------------------------------
+
+        [Fact]
+        public void NewtonsoftHybridCacheSerializer_RoundTrip_PreservesInternalSetterFields_GameServerDto()
+        {
+            // GameServerDto properties use `internal set` + [JsonProperty].
+            // The STJ default would deserialize blank/default values; Newtonsoft must restore them.
+            var serializer = new NewtonsoftHybridCacheSerializer<ApiResult<GameServerDto>>();
+
+            var dto = new GameServerDto();
+            // Use reflection to force-set internal properties for the round-trip assertion.
+            var type = typeof(GameServerDto);
+            type.GetProperty(nameof(GameServerDto.Title))!.SetValue(dto, "Test Server");
+            type.GetProperty(nameof(GameServerDto.Hostname))!.SetValue(dto, "192.168.1.1");
+            type.GetProperty(nameof(GameServerDto.QueryPort))!.SetValue(dto, 27015);
+            type.GetProperty(nameof(GameServerDto.GameType))!.SetValue(dto, GameType.CallOfDuty4);
+
+            var original = Ok(dto);
+
+            // Serialize to bytes then deserialize back.
+            var buffer = new ArrayBufferWriter<byte>();
+            serializer.Serialize(original, buffer);
+            var deserialized = serializer.Deserialize(new ReadOnlySequence<byte>(buffer.WrittenMemory));
+
+            Assert.True(deserialized.IsSuccess);
+            Assert.Equal("Test Server", deserialized.Result!.Data!.Title);
+            Assert.Equal("192.168.1.1", deserialized.Result.Data.Hostname);
+            Assert.Equal(27015, deserialized.Result.Data.QueryPort);
+            Assert.Equal(GameType.CallOfDuty4, deserialized.Result.Data.GameType);
+        }
+
+        [Fact]
+        public void NewtonsoftHybridCacheSerializer_RoundTrip_PreservesInternalSetterFields_ConfigurationDto()
+        {
+            var serializer = new NewtonsoftHybridCacheSerializer<ApiResult<ConfigurationDto>>();
+
+            var dto = new ConfigurationDto();
+            var type = typeof(ConfigurationDto);
+            type.GetProperty(nameof(ConfigurationDto.Namespace))!.SetValue(dto, "ftp");
+            type.GetProperty(nameof(ConfigurationDto.Configuration))!.SetValue(dto, /*lang=json,strict*/ "{\"host\":\"10.0.0.1\"}");
+
+            var original = Ok(dto);
+
+            var buffer = new ArrayBufferWriter<byte>();
+            serializer.Serialize(original, buffer);
+            var deserialized = serializer.Deserialize(new ReadOnlySequence<byte>(buffer.WrittenMemory));
+
+            Assert.True(deserialized.IsSuccess);
+            Assert.Equal("ftp", deserialized.Result!.Data!.Namespace);
+            Assert.Equal(/*lang=json,strict*/ "{\"host\":\"10.0.0.1\"}", deserialized.Result.Data.Configuration);
+        }
+
+        [Fact]
+        public void NewtonsoftHybridCacheSerializer_RoundTrip_PreservesInternalSetterFields_MapDto()
+        {
+            var serializer = new NewtonsoftHybridCacheSerializer<ApiResult<MapDto>>();
+
+            var dto = new MapDto();
+            var type = typeof(MapDto);
+            type.GetProperty(nameof(MapDto.MapId))!.SetValue(dto, Guid.NewGuid());
+            type.GetProperty(nameof(MapDto.MapName))!.SetValue(dto, "mp_crash");
+            type.GetProperty(nameof(MapDto.GameType))!.SetValue(dto, GameType.CallOfDuty4);
+            type.GetProperty(nameof(MapDto.TotalVotes))!.SetValue(dto, 42);
+
+            var original = Ok(dto);
+
+            var buffer = new ArrayBufferWriter<byte>();
+            serializer.Serialize(original, buffer);
+            var deserialized = serializer.Deserialize(new ReadOnlySequence<byte>(buffer.WrittenMemory));
+
+            Assert.True(deserialized.IsSuccess);
+            Assert.Equal("mp_crash", deserialized.Result!.Data!.MapName);
+            Assert.Equal(GameType.CallOfDuty4, deserialized.Result.Data.GameType);
+            Assert.Equal(42, deserialized.Result.Data.TotalVotes);
+        }
+
+        // -----------------------------------------------------------------------
+        // A3 — Key versioning
+        // -----------------------------------------------------------------------
+
+        [Fact]
+        public void RepositoryCacheKeys_AllKeys_ContainSchemaVersion()
+        {
+            var id = Guid.NewGuid();
+            const string ns = "ftp";
+
+            Assert.Contains(RepositoryCacheKeys.SchemaVersion, RepositoryCacheKeys.GameServerKey(id));
+            Assert.Contains(RepositoryCacheKeys.SchemaVersion, RepositoryCacheKeys.DashboardKey("summary", "current"));
+            Assert.Contains(RepositoryCacheKeys.SchemaVersion, RepositoryCacheKeys.SettingsServerKey(id, ns));
+            Assert.Contains(RepositoryCacheKeys.SchemaVersion, RepositoryCacheKeys.SettingsGlobalKey(ns));
+            Assert.Contains(RepositoryCacheKeys.SchemaVersion, RepositoryCacheKeys.SettingsServerCollectionKey(id));
+            Assert.Contains(RepositoryCacheKeys.SchemaVersion, RepositoryCacheKeys.SettingsGlobalCollectionKey);
+            Assert.Contains(RepositoryCacheKeys.SchemaVersion, RepositoryCacheKeys.MapByIdKey(id));
+            Assert.Contains(RepositoryCacheKeys.SchemaVersion, RepositoryCacheKeys.MapByGameNameKey("CallOfDuty4", "mp_crash"));
+            Assert.Contains(RepositoryCacheKeys.SchemaVersion, RepositoryCacheKeys.TagPlayerCountsKey);
+        }
+
+        // -----------------------------------------------------------------------
+        // C1 — Configuration collection caching
+        // -----------------------------------------------------------------------
+
+        private sealed class CountingConfigService : IConfigurationReadService
+        {
+            public int ServerSingleCalls { get; private set; }
+            public int GlobalSingleCalls { get; private set; }
+            public int ServerCollCalls { get; private set; }
+            public int GlobalCollCalls { get; private set; }
+
+            public Task<ApiResult<ConfigurationDto>> GetServerConfigurationAsync(Guid gameServerId, string ns, CancellationToken ct)
+            { ServerSingleCalls++; return Task.FromResult(Ok(new ConfigurationDto())); }
+
+            public Task<ApiResult<ConfigurationDto>> GetGlobalConfigurationAsync(string ns, CancellationToken ct)
+            { GlobalSingleCalls++; return Task.FromResult(Ok(new ConfigurationDto())); }
+
+            public Task<ApiResult<CollectionModel<ConfigurationDto>>> GetServerConfigurationsAsync(Guid gameServerId, CancellationToken ct)
+            { ServerCollCalls++; return Task.FromResult(Ok(new CollectionModel<ConfigurationDto>())); }
+
+            public Task<ApiResult<CollectionModel<ConfigurationDto>>> GetGlobalConfigurationsAsync(CancellationToken ct)
+            { GlobalCollCalls++; return Task.FromResult(Ok(new CollectionModel<ConfigurationDto>())); }
+        }
+
+        [Fact]
+        public async Task CachingConfigReadService_CollectionReads_AreCached()
+        {
+            var inner = new CountingConfigService();
+            var cache = new FakeMxCache();
+            var subject = new CachingConfigurationReadService(inner, cache, CreateMetrics(), NullLogger<CachingConfigurationReadService>.Instance);
+            var id = Guid.NewGuid();
+
+            // Server collection
+            _ = await subject.GetServerConfigurationsAsync(id, CancellationToken.None);
+            _ = await subject.GetServerConfigurationsAsync(id, CancellationToken.None);
+            Assert.Equal(1, inner.ServerCollCalls);
+
+            // Global collection
+            _ = await subject.GetGlobalConfigurationsAsync(CancellationToken.None);
+            _ = await subject.GetGlobalConfigurationsAsync(CancellationToken.None);
+            Assert.Equal(1, inner.GlobalCollCalls);
+        }
+
+        [Fact]
+        public async Task InvalidateServerSettings_EvictsServerCollection_ThroughServerAllTag()
+        {
+            var inner = new CountingConfigService();
+            var cache = new FakeMxCache();
+            var metrics = CreateMetrics();
+            var subject = new CachingConfigurationReadService(inner, cache, metrics, NullLogger<CachingConfigurationReadService>.Instance);
+            var invalidator = new RepositoryCacheInvalidator(cache, metrics, NullLogger<RepositoryCacheInvalidator>.Instance);
+            var id = Guid.NewGuid();
+
+            // Populate server collection + single entry
+            _ = await subject.GetServerConfigurationsAsync(id, CancellationToken.None);
+            _ = await subject.GetServerConfigurationAsync(id, "ftp", CancellationToken.None);
+
+            // Invalidate a single namespace — should also evict collection
+            await invalidator.InvalidateServerSettingsAsync(id, "ftp", CancellationToken.None);
+
+            // Both should miss now
+            _ = await subject.GetServerConfigurationsAsync(id, CancellationToken.None);
+            _ = await subject.GetServerConfigurationAsync(id, "ftp", CancellationToken.None);
+
+            Assert.Equal(2, inner.ServerCollCalls);
+            Assert.Equal(2, inner.ServerSingleCalls);
+        }
+
+        [Fact]
+        public async Task InvalidateGlobalNamespace_EvictsGlobalCollection_ThroughGlobalAllTag()
+        {
+            var inner = new CountingConfigService();
+            var cache = new FakeMxCache();
+            var metrics = CreateMetrics();
+            var subject = new CachingConfigurationReadService(inner, cache, metrics, NullLogger<CachingConfigurationReadService>.Instance);
+            var invalidator = new RepositoryCacheInvalidator(cache, metrics, NullLogger<RepositoryCacheInvalidator>.Instance);
+
+            // Populate global collection + single entry
+            _ = await subject.GetGlobalConfigurationsAsync(CancellationToken.None);
+            _ = await subject.GetGlobalConfigurationAsync("agent", CancellationToken.None);
+
+            // Invalidate single namespace — must also evict collection
+            await invalidator.InvalidateGlobalNamespaceAsync("agent", CancellationToken.None);
+
+            // Both should miss now
+            _ = await subject.GetGlobalConfigurationsAsync(CancellationToken.None);
+            _ = await subject.GetGlobalConfigurationAsync("agent", CancellationToken.None);
+
+            Assert.Equal(2, inner.GlobalCollCalls);
+            Assert.Equal(2, inner.GlobalSingleCalls);
+        }
+
+        // -----------------------------------------------------------------------
+        // C4 — Map caching
+        // -----------------------------------------------------------------------
+
+        private sealed class CountingMapService : IMapReadService
+        {
+            public int ByIdCalls { get; private set; }
+            public int ByGameNameCalls { get; private set; }
+            public Func<Guid, ApiResult<MapDto>>? ByIdFactory { get; set; }
+
+            public Task<ApiResult<MapDto>> GetMapByIdAsync(Guid mapId, CancellationToken ct)
+            { ByIdCalls++; var r = ByIdFactory?.Invoke(mapId) ?? Ok(new MapDto()); return Task.FromResult(r); }
+
+            public Task<ApiResult<MapDto>> GetMapByGameTypeAndNameAsync(GameType gameType, string mapName, CancellationToken ct)
+            { ByGameNameCalls++; return Task.FromResult(Ok(new MapDto())); }
+        }
+
+        [Fact]
+        public async Task CachingMapReadService_ByIdRead_IsCached()
+        {
+            var inner = new CountingMapService();
+            var cache = new FakeMxCache();
+            var subject = new CachingMapReadService(inner, cache, CreateMetrics(), NullLogger<CachingMapReadService>.Instance);
+            var id = Guid.NewGuid();
+
+            _ = await subject.GetMapByIdAsync(id, CancellationToken.None);
+            _ = await subject.GetMapByIdAsync(id, CancellationToken.None);
+
+            Assert.Equal(1, inner.ByIdCalls);
+        }
+
+        [Fact]
+        public async Task CachingMapReadService_DoesNotCache_NotFoundResult()
+        {
+            var inner = new CountingMapService { ByIdFactory = _ => new ApiResult<MapDto>(HttpStatusCode.NotFound) };
+            var cache = new FakeMxCache();
+            var subject = new CachingMapReadService(inner, cache, CreateMetrics(), NullLogger<CachingMapReadService>.Instance);
+            var id = Guid.NewGuid();
+
+            _ = await subject.GetMapByIdAsync(id, CancellationToken.None);
+            _ = await subject.GetMapByIdAsync(id, CancellationToken.None);
+
+            Assert.Equal(2, inner.ByIdCalls);
+        }
+
+        [Fact]
+        public async Task CachingMapReadService_ByGameNameRead_IsCached()
+        {
+            var inner = new CountingMapService();
+            var cache = new FakeMxCache();
+            var subject = new CachingMapReadService(inner, cache, CreateMetrics(), NullLogger<CachingMapReadService>.Instance);
+
+            _ = await subject.GetMapByGameTypeAndNameAsync(GameType.CallOfDuty4, "mp_crash", CancellationToken.None);
+            _ = await subject.GetMapByGameTypeAndNameAsync(GameType.CallOfDuty4, "mp_crash", CancellationToken.None);
+
+            Assert.Equal(1, inner.ByGameNameCalls);
+        }
+
+        [Fact]
+        public async Task InvalidateMap_EvictsById_Entry()
+        {
+            var inner = new CountingMapService();
+            var cache = new FakeMxCache();
+            var metrics = CreateMetrics();
+            var subject = new CachingMapReadService(inner, cache, metrics, NullLogger<CachingMapReadService>.Instance);
+            var invalidator = new RepositoryCacheInvalidator(cache, metrics, NullLogger<RepositoryCacheInvalidator>.Instance);
+            var id = Guid.NewGuid();
+
+            _ = await subject.GetMapByIdAsync(id, CancellationToken.None);
+            await invalidator.InvalidateMapAsync(id, CancellationToken.None);
+            _ = await subject.GetMapByIdAsync(id, CancellationToken.None);
+
+            Assert.Equal(2, inner.ByIdCalls);
+        }
+
+        // -----------------------------------------------------------------------
+        // A5 — Cache resilience (fail-open)
+        // -----------------------------------------------------------------------
+
+        private sealed class ThrowingCache : IMxCache
+        {
+            public Task<T> GetOrCreateAsync<T>(CacheKey key, CachePolicy policy, Func<CancellationToken, ValueTask<T>> factory, CancellationToken cancellationToken = default)
+                => throw new InvalidOperationException("Cache backend unavailable");
+
+            public Task<CacheReadResult<T>> TryGetAsync<T>(CacheKey key, CancellationToken cancellationToken = default)
+                => throw new InvalidOperationException("Cache backend unavailable");
+
+            public Task SetAsync<T>(CacheKey key, T value, CachePolicy policy, CancellationToken cancellationToken = default)
+                => throw new InvalidOperationException("Cache backend unavailable");
+
+            public Task RemoveAsync(CacheKey key, CancellationToken cancellationToken = default)
+                => throw new InvalidOperationException("Cache backend unavailable");
+
+            public Task RemoveByTagAsync(string tag, CancellationToken cancellationToken = default)
+                => throw new InvalidOperationException("Cache backend unavailable");
+        }
+
+        [Fact]
+        public async Task CachingGameServerReadService_CacheFailure_FallsBackToOrigin()
+        {
+            var inner = new CountingGameServerReadService();
+            var subject = new CachingGameServerReadService(inner, new ThrowingCache(), CreateMetrics(), NullLogger<CachingGameServerReadService>.Instance);
+
+            var result = await subject.GetGameServerAsync(Guid.NewGuid(), CancellationToken.None);
+
+            Assert.True(result.IsSuccess);
+            Assert.Equal(1, inner.CallCount);
+        }
+
+        [Fact]
+        public async Task CachingConfigReadService_CacheFailure_FallsBackToOrigin()
+        {
+            var inner = new CountingConfigService();
+            var subject = new CachingConfigurationReadService(inner, new ThrowingCache(), CreateMetrics(), NullLogger<CachingConfigurationReadService>.Instance);
+
+            var result = await subject.GetServerConfigurationAsync(Guid.NewGuid(), "ftp", CancellationToken.None);
+
+            Assert.True(result.IsSuccess);
+            Assert.Equal(1, inner.ServerSingleCalls);
+        }
+
+        [Fact]
+        public async Task CachingMapReadService_CacheFailure_FallsBackToOrigin()
+        {
+            var inner = new CountingMapService();
+            var subject = new CachingMapReadService(inner, new ThrowingCache(), CreateMetrics(), NullLogger<CachingMapReadService>.Instance);
+
+            var result = await subject.GetMapByIdAsync(Guid.NewGuid(), CancellationToken.None);
+
+            Assert.True(result.IsSuccess);
+            Assert.Equal(1, inner.ByIdCalls);
+        }
+
+        [Fact]
+        public async Task RepositoryCacheInvalidator_InvalidationFailure_DoesNotThrow()
+        {
+            // Invalidation failures must NOT propagate to the caller (DB write already succeeded).
+            var invalidator = new RepositoryCacheInvalidator(new ThrowingCache(), CreateMetrics(), NullLogger<RepositoryCacheInvalidator>.Instance);
+            var id = Guid.NewGuid();
+
+            // None of these should throw despite cache being unavailable.
+            await invalidator.InvalidateGameServerAsync(id, CancellationToken.None);
+            await invalidator.InvalidateDashboardAsync(CancellationToken.None);
+            await invalidator.InvalidateServerSettingsAsync(id, "ftp", CancellationToken.None);
+            await invalidator.InvalidateGlobalNamespaceAsync("agent", CancellationToken.None);
+            await invalidator.InvalidateMapAsync(id, CancellationToken.None);
+            await invalidator.InvalidateTagPlayerCountsAsync(CancellationToken.None);
+        }
+
+        // -----------------------------------------------------------------------
+        // Helpers shared with CountingGameServerReadService (re-declared locally)
+        // -----------------------------------------------------------------------
+
+        private sealed class CountingGameServerReadService : IGameServerReadService
+        {
+            public int CallCount { get; private set; }
+
+            public Task<ApiResult<GameServerDto>> GetGameServerAsync(Guid gameServerId, CancellationToken ct)
+            { CallCount++; return Task.FromResult(Ok(new GameServerDto())); }
+        }
+    }
+}

--- a/src/XtremeIdiots.Portal.Repository.Api.Tests.V1/Services/Caching/CachingReadServicesTests.cs
+++ b/src/XtremeIdiots.Portal.Repository.Api.Tests.V1/Services/Caching/CachingReadServicesTests.cs
@@ -5,6 +5,8 @@ using System.Threading.Tasks;
 
 using System.Net;
 
+using Microsoft.Extensions.Logging.Abstractions;
+
 using MX.Api.Abstractions;
 using MX.Caching.Testing;
 
@@ -50,7 +52,7 @@ namespace XtremeIdiots.Portal.Repository.Api.Tests.V1.Services.Caching
         {
             var inner = new CountingGameServerReadService();
             var cache = new FakeMxCache();
-            var subject = new CachingGameServerReadService(inner, cache, CreateMetrics());
+            var subject = new CachingGameServerReadService(inner, cache, CreateMetrics(), NullLogger<CachingGameServerReadService>.Instance);
             var id = Guid.NewGuid();
 
             var first = await subject.GetGameServerAsync(id, CancellationToken.None);
@@ -66,7 +68,7 @@ namespace XtremeIdiots.Portal.Repository.Api.Tests.V1.Services.Caching
         {
             var inner = new CountingGameServerReadService { Factory = _ => new ApiResult<GameServerDto>(HttpStatusCode.NotFound) };
             var cache = new FakeMxCache();
-            var subject = new CachingGameServerReadService(inner, cache, CreateMetrics());
+            var subject = new CachingGameServerReadService(inner, cache, CreateMetrics(), NullLogger<CachingGameServerReadService>.Instance);
             var id = Guid.NewGuid();
 
             _ = await subject.GetGameServerAsync(id, CancellationToken.None);
@@ -81,8 +83,8 @@ namespace XtremeIdiots.Portal.Repository.Api.Tests.V1.Services.Caching
             var inner = new CountingGameServerReadService();
             var cache = new FakeMxCache();
             var metrics = CreateMetrics();
-            var subject = new CachingGameServerReadService(inner, cache, metrics);
-            var invalidator = new RepositoryCacheInvalidator(cache, metrics);
+            var subject = new CachingGameServerReadService(inner, cache, metrics, NullLogger<CachingGameServerReadService>.Instance);
+            var invalidator = new RepositoryCacheInvalidator(cache, metrics, NullLogger<RepositoryCacheInvalidator>.Instance);
             var id = Guid.NewGuid();
 
             _ = await subject.GetGameServerAsync(id, CancellationToken.None);
@@ -98,8 +100,8 @@ namespace XtremeIdiots.Portal.Repository.Api.Tests.V1.Services.Caching
             var inner = new CountingGameServerReadService();
             var cache = new FakeMxCache();
             var metrics = CreateMetrics();
-            var subject = new CachingGameServerReadService(inner, cache, metrics);
-            var invalidator = new RepositoryCacheInvalidator(cache, metrics);
+            var subject = new CachingGameServerReadService(inner, cache, metrics, NullLogger<CachingGameServerReadService>.Instance);
+            var invalidator = new RepositoryCacheInvalidator(cache, metrics, NullLogger<RepositoryCacheInvalidator>.Instance);
             var idA = Guid.NewGuid();
             var idB = Guid.NewGuid();
 
@@ -138,7 +140,7 @@ namespace XtremeIdiots.Portal.Repository.Api.Tests.V1.Services.Caching
         {
             var inner = new CountingDashboardService();
             var cache = new FakeMxCache();
-            var subject = new CachingDashboardService(inner, cache, CreateMetrics());
+            var subject = new CachingDashboardService(inner, cache, CreateMetrics(), NullLogger<CachingDashboardService>.Instance);
 
             _ = await subject.GetDashboardSummaryAsync(CancellationToken.None);
             _ = await subject.GetDashboardSummaryAsync(CancellationToken.None);
@@ -160,7 +162,7 @@ namespace XtremeIdiots.Portal.Repository.Api.Tests.V1.Services.Caching
         {
             var inner = new CountingDashboardService();
             var cache = new FakeMxCache();
-            var subject = new CachingDashboardService(inner, cache, CreateMetrics());
+            var subject = new CachingDashboardService(inner, cache, CreateMetrics(), NullLogger<CachingDashboardService>.Instance);
 
             _ = await subject.GetAdminLeaderboardAsync(30, CancellationToken.None);
             _ = await subject.GetAdminLeaderboardAsync(7, CancellationToken.None);
@@ -176,8 +178,8 @@ namespace XtremeIdiots.Portal.Repository.Api.Tests.V1.Services.Caching
             var inner = new CountingDashboardService();
             var cache = new FakeMxCache();
             var metrics = CreateMetrics();
-            var subject = new CachingDashboardService(inner, cache, metrics);
-            var invalidator = new RepositoryCacheInvalidator(cache, metrics);
+            var subject = new CachingDashboardService(inner, cache, metrics, NullLogger<CachingDashboardService>.Instance);
+            var invalidator = new RepositoryCacheInvalidator(cache, metrics, NullLogger<RepositoryCacheInvalidator>.Instance);
 
             _ = await subject.GetDashboardSummaryAsync(CancellationToken.None);
             _ = await subject.GetAdminLeaderboardAsync(30, CancellationToken.None);
@@ -197,12 +199,20 @@ namespace XtremeIdiots.Portal.Repository.Api.Tests.V1.Services.Caching
         {
             public int ServerCalls { get; private set; }
             public int GlobalCalls { get; private set; }
+            public int ServerCollectionCalls { get; private set; }
+            public int GlobalCollectionCalls { get; private set; }
 
             public Task<ApiResult<ConfigurationDto>> GetServerConfigurationAsync(Guid gameServerId, string ns, CancellationToken cancellationToken)
             { ServerCalls++; return Task.FromResult(Ok(new ConfigurationDto())); }
 
             public Task<ApiResult<ConfigurationDto>> GetGlobalConfigurationAsync(string ns, CancellationToken cancellationToken)
             { GlobalCalls++; return Task.FromResult(Ok(new ConfigurationDto())); }
+
+            public Task<ApiResult<CollectionModel<ConfigurationDto>>> GetServerConfigurationsAsync(Guid gameServerId, CancellationToken cancellationToken)
+            { ServerCollectionCalls++; return Task.FromResult(Ok(new CollectionModel<ConfigurationDto>())); }
+
+            public Task<ApiResult<CollectionModel<ConfigurationDto>>> GetGlobalConfigurationsAsync(CancellationToken cancellationToken)
+            { GlobalCollectionCalls++; return Task.FromResult(Ok(new CollectionModel<ConfigurationDto>())); }
         }
 
         [Fact]
@@ -210,7 +220,7 @@ namespace XtremeIdiots.Portal.Repository.Api.Tests.V1.Services.Caching
         {
             var inner = new CountingConfigurationReadService();
             var cache = new FakeMxCache();
-            var subject = new CachingConfigurationReadService(inner, cache, CreateMetrics());
+            var subject = new CachingConfigurationReadService(inner, cache, CreateMetrics(), NullLogger<CachingConfigurationReadService>.Instance);
             var id = Guid.NewGuid();
 
             _ = await subject.GetServerConfigurationAsync(id, "ftp", CancellationToken.None);
@@ -226,8 +236,8 @@ namespace XtremeIdiots.Portal.Repository.Api.Tests.V1.Services.Caching
             var inner = new CountingConfigurationReadService();
             var cache = new FakeMxCache();
             var metrics = CreateMetrics();
-            var subject = new CachingConfigurationReadService(inner, cache, metrics);
-            var invalidator = new RepositoryCacheInvalidator(cache, metrics);
+            var subject = new CachingConfigurationReadService(inner, cache, metrics, NullLogger<CachingConfigurationReadService>.Instance);
+            var invalidator = new RepositoryCacheInvalidator(cache, metrics, NullLogger<RepositoryCacheInvalidator>.Instance);
             var id = Guid.NewGuid();
 
             _ = await subject.GetServerConfigurationAsync(id, "ftp", CancellationToken.None);
@@ -247,8 +257,8 @@ namespace XtremeIdiots.Portal.Repository.Api.Tests.V1.Services.Caching
             var inner = new CountingConfigurationReadService();
             var cache = new FakeMxCache();
             var metrics = CreateMetrics();
-            var subject = new CachingConfigurationReadService(inner, cache, metrics);
-            var invalidator = new RepositoryCacheInvalidator(cache, metrics);
+            var subject = new CachingConfigurationReadService(inner, cache, metrics, NullLogger<CachingConfigurationReadService>.Instance);
+            var invalidator = new RepositoryCacheInvalidator(cache, metrics, NullLogger<RepositoryCacheInvalidator>.Instance);
 
             var idA = Guid.NewGuid();
             var idB = Guid.NewGuid();
@@ -280,8 +290,8 @@ namespace XtremeIdiots.Portal.Repository.Api.Tests.V1.Services.Caching
             var inner = new CountingConfigurationReadService();
             var cache = new FakeMxCache();
             var metrics = CreateMetrics();
-            var subject = new CachingConfigurationReadService(inner, cache, metrics);
-            var invalidator = new RepositoryCacheInvalidator(cache, metrics);
+            var subject = new CachingConfigurationReadService(inner, cache, metrics, NullLogger<CachingConfigurationReadService>.Instance);
+            var invalidator = new RepositoryCacheInvalidator(cache, metrics, NullLogger<RepositoryCacheInvalidator>.Instance);
             var id = Guid.NewGuid();
 
             var canonical = NamespaceSchemaValidationRegistry.NormalizeNamespace("serverList");
@@ -315,8 +325,8 @@ namespace XtremeIdiots.Portal.Repository.Api.Tests.V1.Services.Caching
             var inner = new CountingConfigurationReadService();
             var cache = new FakeMxCache();
             var metrics = CreateMetrics();
-            var subject = new CachingConfigurationReadService(inner, cache, metrics);
-            var invalidator = new RepositoryCacheInvalidator(cache, metrics);
+            var subject = new CachingConfigurationReadService(inner, cache, metrics, NullLogger<CachingConfigurationReadService>.Instance);
+            var invalidator = new RepositoryCacheInvalidator(cache, metrics, NullLogger<RepositoryCacheInvalidator>.Instance);
             var id = Guid.NewGuid();
 
             var canonical = NamespaceSchemaValidationRegistry.NormalizeNamespace("serverList");

--- a/src/XtremeIdiots.Portal.Repository.Api.Tests.V1/XtremeIdiots.Portal.Repository.Api.Tests.V1.csproj
+++ b/src/XtremeIdiots.Portal.Repository.Api.Tests.V1/XtremeIdiots.Portal.Repository.Api.Tests.V1.csproj
@@ -20,7 +20,7 @@
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
         <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="9.0.18" />
-        <PackageReference Include="MX.Caching.Testing" Version="0.1.5" />
+        <PackageReference Include="MX.Caching.Testing" Version="0.1.6" />
         <!-- Pin patched version to override vulnerable transitive (NU1903: CVE-2026-50648 and related, affected <= 10.0.9) pulled via Microsoft.NET.Test.Sdk. -->
         <PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.10" />
     </ItemGroup>

--- a/src/XtremeIdiots.Portal.Repository.Api.V1/Controllers/V1/GameServerConfigurationsController.cs
+++ b/src/XtremeIdiots.Portal.Repository.Api.V1/Controllers/V1/GameServerConfigurationsController.cs
@@ -54,23 +54,7 @@ public class GameServerConfigurationsController : ControllerBase, IGameServerCon
 
     async Task<ApiResult<CollectionModel<ConfigurationDto>>> IGameServerConfigurationsApi.GetConfigurations(Guid gameServerId, CancellationToken cancellationToken)
     {
-        var gameServerExists = await context.GameServers
-            .AnyAsync(gs => gs.GameServerId == gameServerId, cancellationToken).ConfigureAwait(false);
-
-        if (!gameServerExists)
-        {
-            return new ApiResult<CollectionModel<ConfigurationDto>>(HttpStatusCode.NotFound);
-        }
-
-        var configs = await context.GameServerConfigurations
-            .Where(c => c.GameServerId == gameServerId)
-            .AsNoTracking()
-            .ToListAsync(cancellationToken).ConfigureAwait(false);
-
-        var entries = configs.Select(c => c.ToDto()).ToList();
-        var data = new CollectionModel<ConfigurationDto>(entries);
-
-        return new ApiResponse<CollectionModel<ConfigurationDto>>(data).ToApiResult();
+        return await configurationReadService.GetServerConfigurationsAsync(gameServerId, cancellationToken).ConfigureAwait(false);
     }
 
     [HttpGet("game-servers/{gameServerId:guid}/configurations/{ns}")]

--- a/src/XtremeIdiots.Portal.Repository.Api.V1/Controllers/V1/GlobalConfigurationsController.cs
+++ b/src/XtremeIdiots.Portal.Repository.Api.V1/Controllers/V1/GlobalConfigurationsController.cs
@@ -59,14 +59,7 @@ public class GlobalConfigurationsController : ControllerBase, IGlobalConfigurati
 
     async Task<ApiResult<CollectionModel<ConfigurationDto>>> IGlobalConfigurationsApi.GetConfigurations(CancellationToken cancellationToken)
     {
-        var configs = await context.GlobalConfigurations
-            .AsNoTracking()
-            .ToListAsync(cancellationToken).ConfigureAwait(false);
-
-        var entries = configs.Select(c => c.ToDto()).ToList();
-        var data = new CollectionModel<ConfigurationDto>(entries);
-
-        return new ApiResponse<CollectionModel<ConfigurationDto>>(data).ToApiResult();
+        return await configurationReadService.GetGlobalConfigurationsAsync(cancellationToken).ConfigureAwait(false);
     }
 
     [HttpGet("configurations/{ns}")]

--- a/src/XtremeIdiots.Portal.Repository.Api.V1/Controllers/V1/MapsController.cs
+++ b/src/XtremeIdiots.Portal.Repository.Api.V1/Controllers/V1/MapsController.cs
@@ -379,10 +379,7 @@ namespace XtremeIdiots.Portal.RepositoryWebApi.Controllers.V1
 
             await context.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
 
-            foreach (var editMapDto in editMapDtos)
-            {
-                await cacheInvalidator.InvalidateMapAsync(editMapDto.MapId, cancellationToken).ConfigureAwait(false);
-            }
+            await Task.WhenAll(editMapDtos.Select(dto => cacheInvalidator.InvalidateMapAsync(dto.MapId, cancellationToken))).ConfigureAwait(false);
 
             return new ApiResponse().ToApiResult();
         }
@@ -681,10 +678,7 @@ namespace XtremeIdiots.Portal.RepositoryWebApi.Controllers.V1
 
             await context.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
 
-            foreach (var mapId in mapIds.Distinct())
-            {
-                await cacheInvalidator.InvalidateMapAsync(mapId, cancellationToken).ConfigureAwait(false);
-            }
+            await Task.WhenAll(mapIds.Distinct().Select(id => cacheInvalidator.InvalidateMapAsync(id, cancellationToken))).ConfigureAwait(false);
 
             return new ApiResponse().ToApiResult();
         }

--- a/src/XtremeIdiots.Portal.Repository.Api.V1/Controllers/V1/MapsController.cs
+++ b/src/XtremeIdiots.Portal.Repository.Api.V1/Controllers/V1/MapsController.cs
@@ -20,6 +20,8 @@ using XtremeIdiots.Portal.Repository.Abstractions.Interfaces.V1;
 using XtremeIdiots.Portal.Repository.Abstractions.Models.V1.Maps;
 using XtremeIdiots.Portal.Repository.Api.V1.Extensions;
 using XtremeIdiots.Portal.Repository.Api.V1.Mapping;
+using XtremeIdiots.Portal.Repository.Api.V1.Services;
+using XtremeIdiots.Portal.Repository.Api.V1.Services.Caching;
 
 namespace XtremeIdiots.Portal.RepositoryWebApi.Controllers.V1
 {
@@ -31,15 +33,23 @@ namespace XtremeIdiots.Portal.RepositoryWebApi.Controllers.V1
     {
         private readonly PortalDbContext context;
         private readonly ILogger<MapsController> logger;
+        private readonly IMapReadService mapReadService;
+        private readonly IRepositoryCacheInvalidator cacheInvalidator;
 
         public MapsController(
             PortalDbContext context,
-            ILogger<MapsController> logger)
+            ILogger<MapsController> logger,
+            IMapReadService mapReadService,
+            IRepositoryCacheInvalidator cacheInvalidator)
         {
             ArgumentNullException.ThrowIfNull(context);
             this.context = context;
             ArgumentNullException.ThrowIfNull(logger);
             this.logger = logger;
+            ArgumentNullException.ThrowIfNull(mapReadService);
+            this.mapReadService = mapReadService;
+            ArgumentNullException.ThrowIfNull(cacheInvalidator);
+            this.cacheInvalidator = cacheInvalidator;
         }
 
         /// <summary>
@@ -83,19 +93,7 @@ namespace XtremeIdiots.Portal.RepositoryWebApi.Controllers.V1
         /// <returns>An API result containing the map details if found; otherwise, a 404 Not Found response.</returns>
         async Task<ApiResult<MapDto>> IMapsApi.GetMap(Guid mapId, CancellationToken cancellationToken)
         {
-            var map = await context.Maps
-                .Include(m => m.MapVotes)
-                .AsNoTracking()
-                .FirstOrDefaultAsync(m => m.MapId == mapId, cancellationToken).ConfigureAwait(false);
-
-            if (map == null)
-            {
-                return new ApiResult<MapDto>(HttpStatusCode.NotFound);
-            }
-
-            var result = map.ToDto();
-
-            return new ApiResponse<MapDto>(result).ToApiResult();
+            return await mapReadService.GetMapByIdAsync(mapId, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -107,19 +105,7 @@ namespace XtremeIdiots.Portal.RepositoryWebApi.Controllers.V1
         /// <returns>An API result containing the map details if found; otherwise, a 404 Not Found response.</returns>
         async Task<ApiResult<MapDto>> IMapsApi.GetMap(GameType gameType, string mapName, CancellationToken cancellationToken)
         {
-            var map = await context.Maps
-                .Include(m => m.MapVotes)
-                .AsNoTracking()
-                .FirstOrDefaultAsync(m => m.GameType == gameType.ToGameTypeInt() && m.MapName == mapName, cancellationToken).ConfigureAwait(false);
-
-            if (map == null)
-            {
-                return new ApiResult<MapDto>(HttpStatusCode.NotFound);
-            }
-
-            var result = map.ToDto();
-
-            return new ApiResponse<MapDto>(result).ToApiResult();
+            return await mapReadService.GetMapByGameTypeAndNameAsync(gameType, mapName, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -332,6 +318,7 @@ namespace XtremeIdiots.Portal.RepositoryWebApi.Controllers.V1
 
             editMapDto.ApplyTo(map);
             await context.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+            await cacheInvalidator.InvalidateMapAsync(editMapDto.MapId, cancellationToken).ConfigureAwait(false);
 
             return new ApiResponse().ToApiResult();
         }
@@ -392,6 +379,11 @@ namespace XtremeIdiots.Portal.RepositoryWebApi.Controllers.V1
 
             await context.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
 
+            foreach (var editMapDto in editMapDtos)
+            {
+                await cacheInvalidator.InvalidateMapAsync(editMapDto.MapId, cancellationToken).ConfigureAwait(false);
+            }
+
             return new ApiResponse().ToApiResult();
         }
 
@@ -430,6 +422,7 @@ namespace XtremeIdiots.Portal.RepositoryWebApi.Controllers.V1
             context.Remove(map);
 
             await context.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+            await cacheInvalidator.InvalidateMapAsync(mapId, cancellationToken).ConfigureAwait(false);
 
             return new ApiResponse().ToApiResult();
         }
@@ -561,6 +554,8 @@ namespace XtremeIdiots.Portal.RepositoryWebApi.Controllers.V1
                     GROUP BY [MapId]
                 ) v ON m.[MapId] = v.[MapId]", cancellationToken).ConfigureAwait(false);
 
+            await cacheInvalidator.InvalidateAllMapsAsync(cancellationToken).ConfigureAwait(false);
+
             return new ApiResponse().ToApiResult();
         }
 
@@ -606,6 +601,7 @@ namespace XtremeIdiots.Portal.RepositoryWebApi.Controllers.V1
             }
 
             await context.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+            await cacheInvalidator.InvalidateMapAsync(upsertMapVoteDto.MapId, cancellationToken).ConfigureAwait(false);
 
             return new ApiResponse().ToApiResult();
         }
@@ -684,6 +680,11 @@ namespace XtremeIdiots.Portal.RepositoryWebApi.Controllers.V1
             }
 
             await context.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+
+            foreach (var mapId in mapIds.Distinct())
+            {
+                await cacheInvalidator.InvalidateMapAsync(mapId, cancellationToken).ConfigureAwait(false);
+            }
 
             return new ApiResponse().ToApiResult();
         }
@@ -776,6 +777,7 @@ namespace XtremeIdiots.Portal.RepositoryWebApi.Controllers.V1
             map.MapImageUri = blobClient.Uri.ToString();
 
             await context.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+            await cacheInvalidator.InvalidateMapAsync(mapId, cancellationToken).ConfigureAwait(false);
 
             return new ApiResponse().ToApiResult();
         }
@@ -840,6 +842,7 @@ namespace XtremeIdiots.Portal.RepositoryWebApi.Controllers.V1
 
             map.MapImageUri = null;
             await context.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+            await cacheInvalidator.InvalidateMapAsync(mapId, cancellationToken).ConfigureAwait(false);
 
             return new ApiResponse().ToApiResult();
         }

--- a/src/XtremeIdiots.Portal.Repository.Api.V1/Program.cs
+++ b/src/XtremeIdiots.Portal.Repository.Api.V1/Program.cs
@@ -19,6 +19,7 @@ using MX.Caching;
 using MX.Observability.ApplicationInsights.AspNetCore;
 using Scalar.AspNetCore;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.Extensions.Caching.Hybrid;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -62,10 +63,9 @@ if (!string.IsNullOrWhiteSpace(appConfigEndpoint))
 
 builder.Services.AddSingleton<ITelemetryInitializer, TelemetryInitializer>();
 builder.Services.AddLogging();
-builder.Services.AddMemoryCache(options =>
-{
-    options.SizeLimit = 1024;
-});
+// IMemoryCache without SizeLimit: HybridCache uses IMemoryCache for its L1 tier and does
+// not assign entry sizes; a SizeLimit without entry sizes causes every L1 write to throw.
+builder.Services.AddMemoryCache();
 
 builder.Services.AddApplicationInsightsTelemetry(new ApplicationInsightsServiceOptions
 {
@@ -171,6 +171,13 @@ else
 // backend, and the caching decorators remain functional (per-instance only).
 var mxCachingConfigured = builder.Configuration.GetSection("MxCaching").GetChildren().Any();
 builder.Services.AddMxCaching(builder.Configuration);
+
+// A1 — Serialization correctness: Portal Repository DTOs use internal-set properties
+// decorated with [Newtonsoft.Json.JsonProperty]. HybridCache's default STJ serializer
+// cannot set these properties on deserialization, resulting in blank/default fields on
+// cache hits. Register the Newtonsoft factory so every cached type is round-tripped
+// correctly through the shared Table Storage backend.
+builder.Services.AddSingleton<IHybridCacheSerializerFactory, NewtonsoftHybridCacheSerializerFactory>();
 
 // Repository read-service seams + optional cache-aside decorators.
 builder.Services.AddRepositoryReadServices(enableCaching: mxCachingConfigured);

--- a/src/XtremeIdiots.Portal.Repository.Api.V1/Serialization/NewtonsoftHybridCacheSerializer.cs
+++ b/src/XtremeIdiots.Portal.Repository.Api.V1/Serialization/NewtonsoftHybridCacheSerializer.cs
@@ -1,0 +1,66 @@
+using System.Buffers;
+using System.Diagnostics.CodeAnalysis;
+using System.Text;
+
+using Microsoft.Extensions.Caching.Hybrid;
+
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+
+namespace XtremeIdiots.Portal.Repository.Api.V1.Serialization
+{
+    /// <summary>
+    /// Newtonsoft.Json-backed <see cref="IHybridCacheSerializer{T}"/> for types whose
+    /// properties use <c>internal set</c> and <see cref="JsonPropertyAttribute"/> — patterns
+    /// that System.Text.Json (the HybridCache default) cannot deserialize without extra
+    /// source-generation or reflection configuration.
+    /// </summary>
+    /// <remarks>
+    /// All Portal Repository DTOs are <c>record</c> types with <c>internal set</c> properties
+    /// decorated with <c>[Newtonsoft.Json.JsonProperty]</c>. HybridCache's STJ fallback leaves
+    /// every property at its default value on deserialization because the setters are not
+    /// accessible. This serializer uses the same Newtonsoft settings as the host's MVC pipeline
+    /// (string enums, ignore reference loops, allow non-public constructors) so cached bytes
+    /// are byte-for-byte compatible with the wire format.
+    /// </remarks>
+    public sealed class NewtonsoftHybridCacheSerializer<T> : IHybridCacheSerializer<T>
+    {
+        internal static readonly JsonSerializerSettings Settings = new()
+        {
+            Converters = { new StringEnumConverter() },
+            ReferenceLoopHandling = ReferenceLoopHandling.Ignore,
+            ConstructorHandling = ConstructorHandling.AllowNonPublicDefaultConstructor,
+            TypeNameHandling = TypeNameHandling.None,
+            NullValueHandling = NullValueHandling.Include
+        };
+
+        public T Deserialize(ReadOnlySequence<byte> source)
+        {
+            var json = Encoding.UTF8.GetString(source);
+            return JsonConvert.DeserializeObject<T>(json, Settings)!;
+        }
+
+        public void Serialize(T value, IBufferWriter<byte> target)
+        {
+            var json = JsonConvert.SerializeObject(value, Settings);
+            var bytes = Encoding.UTF8.GetBytes(json);
+            target.Write(bytes);
+        }
+    }
+
+    /// <summary>
+    /// <see cref="IHybridCacheSerializerFactory"/> that returns
+    /// <see cref="NewtonsoftHybridCacheSerializer{T}"/> for every requested type.
+    /// Registered in DI so that <em>all</em> types cached through
+    /// <see cref="MX.Caching.Abstractions.IMxCache"/> in the V1 host use the Newtonsoft
+    /// serializer rather than falling back to System.Text.Json.
+    /// </summary>
+    public sealed class NewtonsoftHybridCacheSerializerFactory : IHybridCacheSerializerFactory
+    {
+        public bool TryCreateSerializer<T>([NotNullWhen(true)] out IHybridCacheSerializer<T>? serializer)
+        {
+            serializer = new NewtonsoftHybridCacheSerializer<T>();
+            return true;
+        }
+    }
+}

--- a/src/XtremeIdiots.Portal.Repository.Api.V1/Services/Caching/CachingConfigurationReadService.cs
+++ b/src/XtremeIdiots.Portal.Repository.Api.V1/Services/Caching/CachingConfigurationReadService.cs
@@ -90,7 +90,14 @@ namespace XtremeIdiots.Portal.Repository.Api.V1.Services.Caching
 
             try
             {
-                var wasMiss = false;
+                var cached = await cache.TryGetAsync<ApiResult<ConfigurationDto>>(key, cancellationToken).ConfigureAwait(false);
+                if (cached.Found)
+                {
+                    metrics.RecordHit(RepositoryCacheKeys.SurfaceSettings);
+                    metrics.RecordLatency(RepositoryCacheKeys.SurfaceSettings, sw.Elapsed.TotalMilliseconds);
+                    return cached.Value!;
+                }
+
                 var result = await cache.GetOrCreateAsync(
                     key,
                     policy,
@@ -101,20 +108,11 @@ namespace XtremeIdiots.Portal.Repository.Api.V1.Services.Caching
                         {
                             throw new FactoryAbortException<ConfigurationDto>(fetched);
                         }
-                        wasMiss = true;
                         return fetched;
                     },
                     cancellationToken).ConfigureAwait(false);
 
-                if (wasMiss)
-                {
-                    metrics.RecordMiss(RepositoryCacheKeys.SurfaceSettings);
-                }
-                else
-                {
-                    metrics.RecordHit(RepositoryCacheKeys.SurfaceSettings);
-                }
-
+                metrics.RecordMiss(RepositoryCacheKeys.SurfaceSettings);
                 metrics.RecordLatency(RepositoryCacheKeys.SurfaceSettings, sw.Elapsed.TotalMilliseconds);
                 return result;
             }
@@ -167,7 +165,14 @@ namespace XtremeIdiots.Portal.Repository.Api.V1.Services.Caching
 
             try
             {
-                var wasMiss = false;
+                var cached = await cache.TryGetAsync<ApiResult<ConfigurationDto>>(key, cancellationToken).ConfigureAwait(false);
+                if (cached.Found)
+                {
+                    metrics.RecordHit(RepositoryCacheKeys.SurfaceSettings);
+                    metrics.RecordLatency(RepositoryCacheKeys.SurfaceSettings, sw.Elapsed.TotalMilliseconds);
+                    return cached.Value!;
+                }
+
                 var result = await cache.GetOrCreateAsync(
                     key,
                     policy,
@@ -178,20 +183,11 @@ namespace XtremeIdiots.Portal.Repository.Api.V1.Services.Caching
                         {
                             throw new FactoryAbortException<ConfigurationDto>(fetched);
                         }
-                        wasMiss = true;
                         return fetched;
                     },
                     cancellationToken).ConfigureAwait(false);
 
-                if (wasMiss)
-                {
-                    metrics.RecordMiss(RepositoryCacheKeys.SurfaceSettings);
-                }
-                else
-                {
-                    metrics.RecordHit(RepositoryCacheKeys.SurfaceSettings);
-                }
-
+                metrics.RecordMiss(RepositoryCacheKeys.SurfaceSettings);
                 metrics.RecordLatency(RepositoryCacheKeys.SurfaceSettings, sw.Elapsed.TotalMilliseconds);
                 return result;
             }
@@ -236,7 +232,14 @@ namespace XtremeIdiots.Portal.Repository.Api.V1.Services.Caching
 
             try
             {
-                var wasMiss = false;
+                var cached = await cache.TryGetAsync<ApiResult<CollectionModel<ConfigurationDto>>>(key, cancellationToken).ConfigureAwait(false);
+                if (cached.Found)
+                {
+                    metrics.RecordHit(RepositoryCacheKeys.SurfaceSettings);
+                    metrics.RecordLatency(RepositoryCacheKeys.SurfaceSettings, sw.Elapsed.TotalMilliseconds);
+                    return cached.Value!;
+                }
+
                 var result = await cache.GetOrCreateAsync(
                     key,
                     policy,
@@ -247,20 +250,11 @@ namespace XtremeIdiots.Portal.Repository.Api.V1.Services.Caching
                         {
                             throw new FactoryAbortException<CollectionModel<ConfigurationDto>>(fetched);
                         }
-                        wasMiss = true;
                         return fetched;
                     },
                     cancellationToken).ConfigureAwait(false);
 
-                if (wasMiss)
-                {
-                    metrics.RecordMiss(RepositoryCacheKeys.SurfaceSettings);
-                }
-                else
-                {
-                    metrics.RecordHit(RepositoryCacheKeys.SurfaceSettings);
-                }
-
+                metrics.RecordMiss(RepositoryCacheKeys.SurfaceSettings);
                 metrics.RecordLatency(RepositoryCacheKeys.SurfaceSettings, sw.Elapsed.TotalMilliseconds);
                 return result;
             }
@@ -302,27 +296,25 @@ namespace XtremeIdiots.Portal.Repository.Api.V1.Services.Caching
 
             try
             {
-                var wasMiss = false;
+                var cached = await cache.TryGetAsync<ApiResult<CollectionModel<ConfigurationDto>>>(key, cancellationToken).ConfigureAwait(false);
+                if (cached.Found)
+                {
+                    metrics.RecordHit(RepositoryCacheKeys.SurfaceSettings);
+                    metrics.RecordLatency(RepositoryCacheKeys.SurfaceSettings, sw.Elapsed.TotalMilliseconds);
+                    return cached.Value!;
+                }
+
                 var result = await cache.GetOrCreateAsync(
                     key,
                     policy,
                     async ct =>
                     {
                         var fetched = await inner.GetGlobalConfigurationsAsync(ct).ConfigureAwait(false);
-                        wasMiss = true;
                         return fetched;
                     },
                     cancellationToken).ConfigureAwait(false);
 
-                if (wasMiss)
-                {
-                    metrics.RecordMiss(RepositoryCacheKeys.SurfaceSettings);
-                }
-                else
-                {
-                    metrics.RecordHit(RepositoryCacheKeys.SurfaceSettings);
-                }
-
+                metrics.RecordMiss(RepositoryCacheKeys.SurfaceSettings);
                 metrics.RecordLatency(RepositoryCacheKeys.SurfaceSettings, sw.Elapsed.TotalMilliseconds);
                 return result;
             }

--- a/src/XtremeIdiots.Portal.Repository.Api.V1/Services/Caching/CachingConfigurationReadService.cs
+++ b/src/XtremeIdiots.Portal.Repository.Api.V1/Services/Caching/CachingConfigurationReadService.cs
@@ -42,6 +42,10 @@ namespace XtremeIdiots.Portal.Repository.Api.V1.Services.Caching
         private readonly RepositoryCacheMetrics metrics;
         private readonly ILogger<CachingConfigurationReadService> logger;
 
+        // Sanitize user-supplied string values before including in log messages to prevent log injection (CWE-117).
+        private static string SanitizeForLog(string value) =>
+            value.Replace("\r", "\\r", StringComparison.Ordinal).Replace("\n", "\\n", StringComparison.Ordinal);
+
         public CachingConfigurationReadService(
             IConfigurationReadService inner,
             IMxCache cache,
@@ -126,13 +130,15 @@ namespace XtremeIdiots.Portal.Repository.Api.V1.Services.Caching
                 logger.LogWarning(
                     ex,
                     "Cache value too large for server config {GameServerId}/{Ns} ({ValueLength} bytes, max {MaximumLength}); skipping cache write.",
-                    gameServerId, ns, ex.ValueLength, ex.MaximumLength);
+                    gameServerId, SanitizeForLog(ns), ex.ValueLength, ex.MaximumLength);
+                metrics.RecordLatency(RepositoryCacheKeys.SurfaceSettings, sw.Elapsed.TotalMilliseconds);
                 metrics.RecordFailure(RepositoryCacheKeys.SurfaceSettings, "oversize");
                 return await inner.GetServerConfigurationAsync(gameServerId, ns, cancellationToken).ConfigureAwait(false);
             }
             catch (Exception ex) when (ex is not OperationCanceledException)
             {
-                logger.LogWarning(ex, "Cache read failed for server config {GameServerId}/{Ns}; falling back to origin.", gameServerId, ns);
+                logger.LogWarning(ex, "Cache read failed for server config {GameServerId}/{Ns}; falling back to origin.", gameServerId, SanitizeForLog(ns));
+                metrics.RecordLatency(RepositoryCacheKeys.SurfaceSettings, sw.Elapsed.TotalMilliseconds);
                 metrics.RecordFailure(RepositoryCacheKeys.SurfaceSettings, "read");
                 return await inner.GetServerConfigurationAsync(gameServerId, ns, cancellationToken).ConfigureAwait(false);
             }
@@ -201,13 +207,15 @@ namespace XtremeIdiots.Portal.Repository.Api.V1.Services.Caching
                 logger.LogWarning(
                     ex,
                     "Cache value too large for global config {Ns} ({ValueLength} bytes, max {MaximumLength}); skipping cache write.",
-                    ns, ex.ValueLength, ex.MaximumLength);
+                    SanitizeForLog(ns), ex.ValueLength, ex.MaximumLength);
+                metrics.RecordLatency(RepositoryCacheKeys.SurfaceSettings, sw.Elapsed.TotalMilliseconds);
                 metrics.RecordFailure(RepositoryCacheKeys.SurfaceSettings, "oversize");
                 return await inner.GetGlobalConfigurationAsync(ns, cancellationToken).ConfigureAwait(false);
             }
             catch (Exception ex) when (ex is not OperationCanceledException)
             {
-                logger.LogWarning(ex, "Cache read failed for global config {Ns}; falling back to origin.", ns);
+                logger.LogWarning(ex, "Cache read failed for global config {Ns}; falling back to origin.", SanitizeForLog(ns));
+                metrics.RecordLatency(RepositoryCacheKeys.SurfaceSettings, sw.Elapsed.TotalMilliseconds);
                 metrics.RecordFailure(RepositoryCacheKeys.SurfaceSettings, "read");
                 return await inner.GetGlobalConfigurationAsync(ns, cancellationToken).ConfigureAwait(false);
             }
@@ -269,12 +277,14 @@ namespace XtremeIdiots.Portal.Repository.Api.V1.Services.Caching
                     ex,
                     "Cache value too large for server config collection {GameServerId} ({ValueLength} bytes, max {MaximumLength}); skipping cache write.",
                     gameServerId, ex.ValueLength, ex.MaximumLength);
+                metrics.RecordLatency(RepositoryCacheKeys.SurfaceSettings, sw.Elapsed.TotalMilliseconds);
                 metrics.RecordFailure(RepositoryCacheKeys.SurfaceSettings, "oversize");
                 return await inner.GetServerConfigurationsAsync(gameServerId, cancellationToken).ConfigureAwait(false);
             }
             catch (Exception ex) when (ex is not OperationCanceledException)
             {
                 logger.LogWarning(ex, "Cache read failed for server config collection {GameServerId}; falling back to origin.", gameServerId);
+                metrics.RecordLatency(RepositoryCacheKeys.SurfaceSettings, sw.Elapsed.TotalMilliseconds);
                 metrics.RecordFailure(RepositoryCacheKeys.SurfaceSettings, "read");
                 return await inner.GetServerConfigurationsAsync(gameServerId, cancellationToken).ConfigureAwait(false);
             }
@@ -324,12 +334,14 @@ namespace XtremeIdiots.Portal.Repository.Api.V1.Services.Caching
                     ex,
                     "Cache value too large for global config collection ({ValueLength} bytes, max {MaximumLength}); skipping cache write.",
                     ex.ValueLength, ex.MaximumLength);
+                metrics.RecordLatency(RepositoryCacheKeys.SurfaceSettings, sw.Elapsed.TotalMilliseconds);
                 metrics.RecordFailure(RepositoryCacheKeys.SurfaceSettings, "oversize");
                 return await inner.GetGlobalConfigurationsAsync(cancellationToken).ConfigureAwait(false);
             }
             catch (Exception ex) when (ex is not OperationCanceledException)
             {
                 logger.LogWarning(ex, "Cache read failed for global config collection; falling back to origin.");
+                metrics.RecordLatency(RepositoryCacheKeys.SurfaceSettings, sw.Elapsed.TotalMilliseconds);
                 metrics.RecordFailure(RepositoryCacheKeys.SurfaceSettings, "read");
                 return await inner.GetGlobalConfigurationsAsync(cancellationToken).ConfigureAwait(false);
             }

--- a/src/XtremeIdiots.Portal.Repository.Api.V1/Services/Caching/CachingConfigurationReadService.cs
+++ b/src/XtremeIdiots.Portal.Repository.Api.V1/Services/Caching/CachingConfigurationReadService.cs
@@ -1,33 +1,61 @@
+using System.Diagnostics;
+
 using MX.Api.Abstractions;
 using MX.Caching.Abstractions;
+using MX.Caching.TableStorage;
 
 using XtremeIdiots.Portal.Repository.Abstractions.Models.V1.Configurations;
 using XtremeIdiots.Portal.Repository.Api.V1.Validation;
 
+using Microsoft.Extensions.Logging;
+
 namespace XtremeIdiots.Portal.Repository.Api.V1.Services.Caching
 {
     /// <summary>
-    /// Cache-aside decorator over <see cref="IConfigurationReadService"/>. Entries are stored
-    /// with a 5-minute TTL and dual tags — one precise, one namespace-scoped — so a global
+    /// Cache-aside decorator over <see cref="IConfigurationReadService"/>. Single-namespace
+    /// entries are stored with dual tags — one precise, one namespace-scoped — so a global
     /// upsert can invalidate every server's resolved entry for that namespace across all
-    /// Repository API instances via the shared Table Storage tag index.
+    /// Repository API instances via the shared Table Storage tag index. Collection entries
+    /// are tagged globally/per-server so any mutation to any namespace invalidates the
+    /// corresponding collection read.
     /// </summary>
+    /// <remarks>
+    /// <b>Tiered policy:</b>
+    /// <list type="bullet">
+    ///   <item>L1 (in-process) TTL: 45 seconds — bounds stale exposure within a single instance.</item>
+    ///   <item>L2 (distributed / Table Storage) TTL: 5 minutes — shared across all instances.</item>
+    /// </list>
+    /// Maximum bounded stale window = L1 TTL = 45 seconds after a cross-instance tag invalidation.
+    /// </remarks>
     public sealed class CachingConfigurationReadService : IConfigurationReadService
     {
-        internal static readonly TimeSpan Ttl = TimeSpan.FromMinutes(5);
+        internal static readonly TimeSpan L1Ttl = TimeSpan.FromSeconds(45);
+        internal static readonly TimeSpan L2Ttl = TimeSpan.FromMinutes(5);
+
+        private sealed class FactoryAbortException<T>(ApiResult<T> result) : Exception
+        {
+            public ApiResult<T> Result { get; } = result;
+        }
 
         private readonly IConfigurationReadService inner;
         private readonly IMxCache cache;
         private readonly RepositoryCacheMetrics metrics;
+        private readonly ILogger<CachingConfigurationReadService> logger;
 
-        public CachingConfigurationReadService(IConfigurationReadService inner, IMxCache cache, RepositoryCacheMetrics metrics)
+        public CachingConfigurationReadService(
+            IConfigurationReadService inner,
+            IMxCache cache,
+            RepositoryCacheMetrics metrics,
+            ILogger<CachingConfigurationReadService> logger)
         {
             ArgumentNullException.ThrowIfNull(inner);
             ArgumentNullException.ThrowIfNull(cache);
             ArgumentNullException.ThrowIfNull(metrics);
+            ArgumentNullException.ThrowIfNull(logger);
             this.inner = inner;
             this.cache = cache;
             this.metrics = metrics;
+            this.logger = logger;
         }
 
         public async Task<ApiResult<ConfigurationDto>> GetServerConfigurationAsync(Guid gameServerId, string ns, CancellationToken cancellationToken)
@@ -41,39 +69,75 @@ namespace XtremeIdiots.Portal.Repository.Api.V1.Services.Caching
             }
 
             // Normalize the namespace (e.g. legacy alias "serverList" -> canonical) so cache
-            // keys/tags stay aligned with those used by the write-path invalidator; otherwise
-            // an alias-scoped entry would survive canonical-scoped invalidation until TTL.
+            // keys/tags stay aligned with those used by the write-path invalidator.
             ns = NamespaceSchemaValidationRegistry.NormalizeNamespace(ns);
 
             var key = new CacheKey(RepositoryCacheKeys.SettingsServerKey(gameServerId, ns));
+            var sw = Stopwatch.StartNew();
 
-            var existing = await cache.TryGetAsync<ApiResult<ConfigurationDto>>(key, cancellationToken).ConfigureAwait(false);
-            if (existing.Found)
+            var policy = new CachePolicy
             {
-                metrics.RecordHit(RepositoryCacheKeys.SurfaceSettings);
-                return existing.Value!;
-            }
-
-            metrics.RecordMiss(RepositoryCacheKeys.SurfaceSettings);
-            var fetched = await inner.GetServerConfigurationAsync(gameServerId, ns, cancellationToken).ConfigureAwait(false);
-
-            if (fetched.IsSuccess)
-            {
-                var policy = new CachePolicy
+                Enabled = true,
+                Tier = CacheTier.Tiered,
+                L1Ttl = L1Ttl,
+                Ttl = L2Ttl,
+                Tags = new[]
                 {
-                    Enabled = true,
-                    Tier = CacheTier.Distributed,
-                    Ttl = Ttl,
-                    Tags = new[]
-                    {
-                        RepositoryCacheKeys.SettingsServerTag(gameServerId, ns),
-                        RepositoryCacheKeys.SettingsNamespaceTag(ns)
-                    }
-                };
-                await cache.SetAsync(key, fetched, policy, cancellationToken).ConfigureAwait(false);
-            }
+                    RepositoryCacheKeys.SettingsServerTag(gameServerId, ns),
+                    RepositoryCacheKeys.SettingsNamespaceTag(ns)
+                }
+            };
 
-            return fetched;
+            try
+            {
+                var wasMiss = false;
+                var result = await cache.GetOrCreateAsync(
+                    key,
+                    policy,
+                    async ct =>
+                    {
+                        var fetched = await inner.GetServerConfigurationAsync(gameServerId, ns, ct).ConfigureAwait(false);
+                        if (!fetched.IsSuccess)
+                        {
+                            throw new FactoryAbortException<ConfigurationDto>(fetched);
+                        }
+                        wasMiss = true;
+                        return fetched;
+                    },
+                    cancellationToken).ConfigureAwait(false);
+
+                if (wasMiss)
+                {
+                    metrics.RecordMiss(RepositoryCacheKeys.SurfaceSettings);
+                }
+                else
+                {
+                    metrics.RecordHit(RepositoryCacheKeys.SurfaceSettings);
+                }
+
+                metrics.RecordLatency(RepositoryCacheKeys.SurfaceSettings, sw.Elapsed.TotalMilliseconds);
+                return result;
+            }
+            catch (FactoryAbortException<ConfigurationDto> ex)
+            {
+                metrics.RecordLatency(RepositoryCacheKeys.SurfaceSettings, sw.Elapsed.TotalMilliseconds);
+                return ex.Result;
+            }
+            catch (CacheValueTooLargeException ex)
+            {
+                logger.LogWarning(
+                    ex,
+                    "Cache value too large for server config {GameServerId}/{Ns} ({ValueLength} bytes, max {MaximumLength}); skipping cache write.",
+                    gameServerId, ns, ex.ValueLength, ex.MaximumLength);
+                metrics.RecordFailure(RepositoryCacheKeys.SurfaceSettings, "oversize");
+                return await inner.GetServerConfigurationAsync(gameServerId, ns, cancellationToken).ConfigureAwait(false);
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException)
+            {
+                logger.LogWarning(ex, "Cache read failed for server config {GameServerId}/{Ns}; falling back to origin.", gameServerId, ns);
+                metrics.RecordFailure(RepositoryCacheKeys.SurfaceSettings, "read");
+                return await inner.GetServerConfigurationAsync(gameServerId, ns, cancellationToken).ConfigureAwait(false);
+            }
         }
 
         public async Task<ApiResult<ConfigurationDto>> GetGlobalConfigurationAsync(string ns, CancellationToken cancellationToken)
@@ -86,34 +150,197 @@ namespace XtremeIdiots.Portal.Repository.Api.V1.Services.Caching
             ns = NamespaceSchemaValidationRegistry.NormalizeNamespace(ns);
 
             var key = new CacheKey(RepositoryCacheKeys.SettingsGlobalKey(ns));
+            var sw = Stopwatch.StartNew();
 
-            var existing = await cache.TryGetAsync<ApiResult<ConfigurationDto>>(key, cancellationToken).ConfigureAwait(false);
-            if (existing.Found)
+            var policy = new CachePolicy
             {
-                metrics.RecordHit(RepositoryCacheKeys.SurfaceSettings);
-                return existing.Value!;
-            }
-
-            metrics.RecordMiss(RepositoryCacheKeys.SurfaceSettings);
-            var fetched = await inner.GetGlobalConfigurationAsync(ns, cancellationToken).ConfigureAwait(false);
-
-            if (fetched.IsSuccess)
-            {
-                var policy = new CachePolicy
+                Enabled = true,
+                Tier = CacheTier.Tiered,
+                L1Ttl = L1Ttl,
+                Ttl = L2Ttl,
+                Tags = new[]
                 {
-                    Enabled = true,
-                    Tier = CacheTier.Distributed,
-                    Ttl = Ttl,
-                    Tags = new[]
-                    {
-                        RepositoryCacheKeys.SettingsGlobalTag(ns),
-                        RepositoryCacheKeys.SettingsNamespaceTag(ns)
-                    }
-                };
-                await cache.SetAsync(key, fetched, policy, cancellationToken).ConfigureAwait(false);
-            }
+                    RepositoryCacheKeys.SettingsGlobalTag(ns),
+                    RepositoryCacheKeys.SettingsNamespaceTag(ns)
+                }
+            };
 
-            return fetched;
+            try
+            {
+                var wasMiss = false;
+                var result = await cache.GetOrCreateAsync(
+                    key,
+                    policy,
+                    async ct =>
+                    {
+                        var fetched = await inner.GetGlobalConfigurationAsync(ns, ct).ConfigureAwait(false);
+                        if (!fetched.IsSuccess)
+                        {
+                            throw new FactoryAbortException<ConfigurationDto>(fetched);
+                        }
+                        wasMiss = true;
+                        return fetched;
+                    },
+                    cancellationToken).ConfigureAwait(false);
+
+                if (wasMiss)
+                {
+                    metrics.RecordMiss(RepositoryCacheKeys.SurfaceSettings);
+                }
+                else
+                {
+                    metrics.RecordHit(RepositoryCacheKeys.SurfaceSettings);
+                }
+
+                metrics.RecordLatency(RepositoryCacheKeys.SurfaceSettings, sw.Elapsed.TotalMilliseconds);
+                return result;
+            }
+            catch (FactoryAbortException<ConfigurationDto> ex)
+            {
+                metrics.RecordLatency(RepositoryCacheKeys.SurfaceSettings, sw.Elapsed.TotalMilliseconds);
+                return ex.Result;
+            }
+            catch (CacheValueTooLargeException ex)
+            {
+                logger.LogWarning(
+                    ex,
+                    "Cache value too large for global config {Ns} ({ValueLength} bytes, max {MaximumLength}); skipping cache write.",
+                    ns, ex.ValueLength, ex.MaximumLength);
+                metrics.RecordFailure(RepositoryCacheKeys.SurfaceSettings, "oversize");
+                return await inner.GetGlobalConfigurationAsync(ns, cancellationToken).ConfigureAwait(false);
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException)
+            {
+                logger.LogWarning(ex, "Cache read failed for global config {Ns}; falling back to origin.", ns);
+                metrics.RecordFailure(RepositoryCacheKeys.SurfaceSettings, "read");
+                return await inner.GetGlobalConfigurationAsync(ns, cancellationToken).ConfigureAwait(false);
+            }
+        }
+
+        public async Task<ApiResult<CollectionModel<ConfigurationDto>>> GetServerConfigurationsAsync(Guid gameServerId, CancellationToken cancellationToken)
+        {
+            var key = new CacheKey(RepositoryCacheKeys.SettingsServerCollectionKey(gameServerId));
+            var sw = Stopwatch.StartNew();
+
+            var policy = new CachePolicy
+            {
+                Enabled = true,
+                Tier = CacheTier.Tiered,
+                L1Ttl = L1Ttl,
+                Ttl = L2Ttl,
+                Tags = new[]
+                {
+                    RepositoryCacheKeys.SettingsServerAllTag(gameServerId)
+                }
+            };
+
+            try
+            {
+                var wasMiss = false;
+                var result = await cache.GetOrCreateAsync(
+                    key,
+                    policy,
+                    async ct =>
+                    {
+                        var fetched = await inner.GetServerConfigurationsAsync(gameServerId, ct).ConfigureAwait(false);
+                        if (!fetched.IsSuccess)
+                        {
+                            throw new FactoryAbortException<CollectionModel<ConfigurationDto>>(fetched);
+                        }
+                        wasMiss = true;
+                        return fetched;
+                    },
+                    cancellationToken).ConfigureAwait(false);
+
+                if (wasMiss)
+                {
+                    metrics.RecordMiss(RepositoryCacheKeys.SurfaceSettings);
+                }
+                else
+                {
+                    metrics.RecordHit(RepositoryCacheKeys.SurfaceSettings);
+                }
+
+                metrics.RecordLatency(RepositoryCacheKeys.SurfaceSettings, sw.Elapsed.TotalMilliseconds);
+                return result;
+            }
+            catch (FactoryAbortException<CollectionModel<ConfigurationDto>> ex)
+            {
+                metrics.RecordLatency(RepositoryCacheKeys.SurfaceSettings, sw.Elapsed.TotalMilliseconds);
+                return ex.Result;
+            }
+            catch (CacheValueTooLargeException ex)
+            {
+                logger.LogWarning(
+                    ex,
+                    "Cache value too large for server config collection {GameServerId} ({ValueLength} bytes, max {MaximumLength}); skipping cache write.",
+                    gameServerId, ex.ValueLength, ex.MaximumLength);
+                metrics.RecordFailure(RepositoryCacheKeys.SurfaceSettings, "oversize");
+                return await inner.GetServerConfigurationsAsync(gameServerId, cancellationToken).ConfigureAwait(false);
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException)
+            {
+                logger.LogWarning(ex, "Cache read failed for server config collection {GameServerId}; falling back to origin.", gameServerId);
+                metrics.RecordFailure(RepositoryCacheKeys.SurfaceSettings, "read");
+                return await inner.GetServerConfigurationsAsync(gameServerId, cancellationToken).ConfigureAwait(false);
+            }
+        }
+
+        public async Task<ApiResult<CollectionModel<ConfigurationDto>>> GetGlobalConfigurationsAsync(CancellationToken cancellationToken)
+        {
+            var key = new CacheKey(RepositoryCacheKeys.SettingsGlobalCollectionKey);
+            var sw = Stopwatch.StartNew();
+
+            var policy = new CachePolicy
+            {
+                Enabled = true,
+                Tier = CacheTier.Tiered,
+                L1Ttl = L1Ttl,
+                Ttl = L2Ttl,
+                Tags = new[] { RepositoryCacheKeys.SettingsGlobalAllTag }
+            };
+
+            try
+            {
+                var wasMiss = false;
+                var result = await cache.GetOrCreateAsync(
+                    key,
+                    policy,
+                    async ct =>
+                    {
+                        var fetched = await inner.GetGlobalConfigurationsAsync(ct).ConfigureAwait(false);
+                        wasMiss = true;
+                        return fetched;
+                    },
+                    cancellationToken).ConfigureAwait(false);
+
+                if (wasMiss)
+                {
+                    metrics.RecordMiss(RepositoryCacheKeys.SurfaceSettings);
+                }
+                else
+                {
+                    metrics.RecordHit(RepositoryCacheKeys.SurfaceSettings);
+                }
+
+                metrics.RecordLatency(RepositoryCacheKeys.SurfaceSettings, sw.Elapsed.TotalMilliseconds);
+                return result;
+            }
+            catch (CacheValueTooLargeException ex)
+            {
+                logger.LogWarning(
+                    ex,
+                    "Cache value too large for global config collection ({ValueLength} bytes, max {MaximumLength}); skipping cache write.",
+                    ex.ValueLength, ex.MaximumLength);
+                metrics.RecordFailure(RepositoryCacheKeys.SurfaceSettings, "oversize");
+                return await inner.GetGlobalConfigurationsAsync(cancellationToken).ConfigureAwait(false);
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException)
+            {
+                logger.LogWarning(ex, "Cache read failed for global config collection; falling back to origin.");
+                metrics.RecordFailure(RepositoryCacheKeys.SurfaceSettings, "read");
+                return await inner.GetGlobalConfigurationsAsync(cancellationToken).ConfigureAwait(false);
+            }
         }
     }
 }

--- a/src/XtremeIdiots.Portal.Repository.Api.V1/Services/Caching/CachingDashboardService.cs
+++ b/src/XtremeIdiots.Portal.Repository.Api.V1/Services/Caching/CachingDashboardService.cs
@@ -90,7 +90,14 @@ namespace XtremeIdiots.Portal.Repository.Api.V1.Services.Caching
 
             try
             {
-                var wasMiss = false;
+                var cached = await cache.TryGetAsync<ApiResult<T>>(key, cancellationToken).ConfigureAwait(false);
+                if (cached.Found)
+                {
+                    metrics.RecordHit(RepositoryCacheKeys.SurfaceDashboard);
+                    metrics.RecordLatency(RepositoryCacheKeys.SurfaceDashboard, sw.Elapsed.TotalMilliseconds);
+                    return cached.Value!;
+                }
+
                 var result = await cache.GetOrCreateAsync(
                     key,
                     policy,
@@ -102,20 +109,11 @@ namespace XtremeIdiots.Portal.Repository.Api.V1.Services.Caching
                             throw new FactoryAbortException<T>(fetched);
                         }
 
-                        wasMiss = true;
                         return fetched;
                     },
                     cancellationToken).ConfigureAwait(false);
 
-                if (wasMiss)
-                {
-                    metrics.RecordMiss(RepositoryCacheKeys.SurfaceDashboard);
-                }
-                else
-                {
-                    metrics.RecordHit(RepositoryCacheKeys.SurfaceDashboard);
-                }
-
+                metrics.RecordMiss(RepositoryCacheKeys.SurfaceDashboard);
                 metrics.RecordLatency(RepositoryCacheKeys.SurfaceDashboard, sw.Elapsed.TotalMilliseconds);
                 return result;
             }

--- a/src/XtremeIdiots.Portal.Repository.Api.V1/Services/Caching/CachingDashboardService.cs
+++ b/src/XtremeIdiots.Portal.Repository.Api.V1/Services/Caching/CachingDashboardService.cs
@@ -1,81 +1,145 @@
+using System.Diagnostics;
+
 using MX.Api.Abstractions;
 using MX.Caching.Abstractions;
+using MX.Caching.TableStorage;
 
 using XtremeIdiots.Portal.Repository.Abstractions.Models.V1.Dashboard;
+
+using Microsoft.Extensions.Logging;
 
 namespace XtremeIdiots.Portal.Repository.Api.V1.Services.Caching
 {
     /// <summary>
     /// Cache-aside decorator over <see cref="IDashboardService"/>. All four aggregations are
-    /// stored with a 90-second TTL (mid-point of the 60–120s window in the work package) and
-    /// tagged <c>dashboard</c> so any admin action mutation can evict the whole surface via
-    /// <see cref="IRepositoryCacheInvalidator.InvalidateDashboardAsync"/>.
+    /// stored with Tiered policies and tagged <c>dashboard</c> so any admin action mutation
+    /// can evict the whole surface via <see cref="IRepositoryCacheInvalidator.InvalidateDashboardAsync"/>.
     /// </summary>
+    /// <remarks>
+    /// <b>Tiered policy:</b>
+    /// <list type="bullet">
+    ///   <item>L1 (in-process) TTL: 22 seconds — bounds stale exposure within a single instance.</item>
+    ///   <item>L2 (distributed / Table Storage) TTL: 90 seconds — shared across all instances.</item>
+    /// </list>
+    /// Maximum bounded stale window = L1 TTL = 22 seconds after a cross-instance tag invalidation.
+    /// </remarks>
     public sealed class CachingDashboardService : IDashboardService
     {
-        internal static readonly TimeSpan Ttl = TimeSpan.FromSeconds(90);
+        internal static readonly TimeSpan L1Ttl = TimeSpan.FromSeconds(22);
+        internal static readonly TimeSpan L2Ttl = TimeSpan.FromSeconds(90);
+
+        private sealed class FactoryAbortException<T>(ApiResult<T> result) : Exception
+        {
+            public ApiResult<T> Result { get; } = result;
+        }
 
         private readonly IDashboardService inner;
         private readonly IMxCache cache;
         private readonly RepositoryCacheMetrics metrics;
+        private readonly ILogger<CachingDashboardService> logger;
 
-        public CachingDashboardService(IDashboardService inner, IMxCache cache, RepositoryCacheMetrics metrics)
+        public CachingDashboardService(
+            IDashboardService inner,
+            IMxCache cache,
+            RepositoryCacheMetrics metrics,
+            ILogger<CachingDashboardService> logger)
         {
             ArgumentNullException.ThrowIfNull(inner);
             ArgumentNullException.ThrowIfNull(cache);
             ArgumentNullException.ThrowIfNull(metrics);
+            ArgumentNullException.ThrowIfNull(logger);
             this.inner = inner;
             this.cache = cache;
             this.metrics = metrics;
+            this.logger = logger;
         }
 
         public Task<ApiResult<DashboardSummaryDto>> GetDashboardSummaryAsync(CancellationToken cancellationToken)
             => GetOrCreateAsync("summary", "current",
-                (ct) => inner.GetDashboardSummaryAsync(ct),
+                ct => inner.GetDashboardSummaryAsync(ct),
                 cancellationToken);
 
         public Task<ApiResult<CollectionModel<AdminLeaderboardEntryDto>>> GetAdminLeaderboardAsync(int days, CancellationToken cancellationToken)
             => GetOrCreateAsync("admin-leaderboard", DaysWindow(days),
-                (ct) => inner.GetAdminLeaderboardAsync(days, ct),
+                ct => inner.GetAdminLeaderboardAsync(days, ct),
                 cancellationToken);
 
         public Task<ApiResult<CollectionModel<ModerationTrendDataPointDto>>> GetModerationTrendAsync(int days, CancellationToken cancellationToken)
             => GetOrCreateAsync("moderation-trend", DaysWindow(days),
-                (ct) => inner.GetModerationTrendAsync(days, ct),
+                ct => inner.GetModerationTrendAsync(days, ct),
                 cancellationToken);
 
         public Task<ApiResult<ServerUtilizationCollectionDto>> GetServerUtilizationAsync(CancellationToken cancellationToken)
             => GetOrCreateAsync("server-utilization", "24h",
-                (ct) => inner.GetServerUtilizationAsync(ct),
+                ct => inner.GetServerUtilizationAsync(ct),
                 cancellationToken);
 
         private async Task<ApiResult<T>> GetOrCreateAsync<T>(string metric, string window, Func<CancellationToken, Task<ApiResult<T>>> factory, CancellationToken cancellationToken)
         {
             var key = new CacheKey(RepositoryCacheKeys.DashboardKey(metric, window));
+            var sw = Stopwatch.StartNew();
 
-            var existing = await cache.TryGetAsync<ApiResult<T>>(key, cancellationToken).ConfigureAwait(false);
-            if (existing.Found)
+            var policy = new CachePolicy
             {
-                metrics.RecordHit(RepositoryCacheKeys.SurfaceDashboard);
-                return existing.Value!;
-            }
+                Enabled = true,
+                Tier = CacheTier.Tiered,
+                L1Ttl = L1Ttl,
+                Ttl = L2Ttl,
+                Tags = new[] { RepositoryCacheKeys.DashboardTag }
+            };
 
-            metrics.RecordMiss(RepositoryCacheKeys.SurfaceDashboard);
-            var fetched = await factory(cancellationToken).ConfigureAwait(false);
-
-            if (fetched.IsSuccess)
+            try
             {
-                var policy = new CachePolicy
+                var wasMiss = false;
+                var result = await cache.GetOrCreateAsync(
+                    key,
+                    policy,
+                    async ct =>
+                    {
+                        var fetched = await factory(ct).ConfigureAwait(false);
+                        if (!fetched.IsSuccess)
+                        {
+                            throw new FactoryAbortException<T>(fetched);
+                        }
+
+                        wasMiss = true;
+                        return fetched;
+                    },
+                    cancellationToken).ConfigureAwait(false);
+
+                if (wasMiss)
                 {
-                    Enabled = true,
-                    Tier = CacheTier.Distributed,
-                    Ttl = Ttl,
-                    Tags = new[] { RepositoryCacheKeys.DashboardTag }
-                };
-                await cache.SetAsync(key, fetched, policy, cancellationToken).ConfigureAwait(false);
-            }
+                    metrics.RecordMiss(RepositoryCacheKeys.SurfaceDashboard);
+                }
+                else
+                {
+                    metrics.RecordHit(RepositoryCacheKeys.SurfaceDashboard);
+                }
 
-            return fetched;
+                metrics.RecordLatency(RepositoryCacheKeys.SurfaceDashboard, sw.Elapsed.TotalMilliseconds);
+                return result;
+            }
+            catch (FactoryAbortException<T> ex)
+            {
+                metrics.RecordLatency(RepositoryCacheKeys.SurfaceDashboard, sw.Elapsed.TotalMilliseconds);
+                return ex.Result;
+            }
+            catch (CacheValueTooLargeException ex)
+            {
+                logger.LogWarning(
+                    ex,
+                    "Cache value too large for dashboard {Metric}/{Window} ({ValueLength} bytes, max {MaximumLength}); skipping cache write.",
+                    metric, window, ex.ValueLength, ex.MaximumLength);
+                metrics.RecordFailure(RepositoryCacheKeys.SurfaceDashboard, "oversize");
+                return await factory(cancellationToken).ConfigureAwait(false);
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException)
+            {
+                // A5 — resilience: cache failure falls back to authoritative SQL path.
+                logger.LogWarning(ex, "Cache read failed for dashboard {Metric}/{Window}; falling back to origin.", metric, window);
+                metrics.RecordFailure(RepositoryCacheKeys.SurfaceDashboard, "read");
+                return await factory(cancellationToken).ConfigureAwait(false);
+            }
         }
 
         private static string DaysWindow(int days) => days <= 0 ? "30d" : $"{days}d";

--- a/src/XtremeIdiots.Portal.Repository.Api.V1/Services/Caching/CachingDashboardService.cs
+++ b/src/XtremeIdiots.Portal.Repository.Api.V1/Services/Caching/CachingDashboardService.cs
@@ -128,6 +128,7 @@ namespace XtremeIdiots.Portal.Repository.Api.V1.Services.Caching
                     ex,
                     "Cache value too large for dashboard {Metric}/{Window} ({ValueLength} bytes, max {MaximumLength}); skipping cache write.",
                     metric, window, ex.ValueLength, ex.MaximumLength);
+                metrics.RecordLatency(RepositoryCacheKeys.SurfaceDashboard, sw.Elapsed.TotalMilliseconds);
                 metrics.RecordFailure(RepositoryCacheKeys.SurfaceDashboard, "oversize");
                 return await factory(cancellationToken).ConfigureAwait(false);
             }
@@ -135,6 +136,7 @@ namespace XtremeIdiots.Portal.Repository.Api.V1.Services.Caching
             {
                 // A5 — resilience: cache failure falls back to authoritative SQL path.
                 logger.LogWarning(ex, "Cache read failed for dashboard {Metric}/{Window}; falling back to origin.", metric, window);
+                metrics.RecordLatency(RepositoryCacheKeys.SurfaceDashboard, sw.Elapsed.TotalMilliseconds);
                 metrics.RecordFailure(RepositoryCacheKeys.SurfaceDashboard, "read");
                 return await factory(cancellationToken).ConfigureAwait(false);
             }

--- a/src/XtremeIdiots.Portal.Repository.Api.V1/Services/Caching/CachingGameServerReadService.cs
+++ b/src/XtremeIdiots.Portal.Repository.Api.V1/Services/Caching/CachingGameServerReadService.cs
@@ -74,7 +74,14 @@ namespace XtremeIdiots.Portal.Repository.Api.V1.Services.Caching
 
             try
             {
-                var wasMiss = false;
+                var cached = await cache.TryGetAsync<ApiResult<GameServerDto>>(key, cancellationToken).ConfigureAwait(false);
+                if (cached.Found)
+                {
+                    metrics.RecordHit(RepositoryCacheKeys.SurfaceGameServer);
+                    metrics.RecordLatency(RepositoryCacheKeys.SurfaceGameServer, sw.Elapsed.TotalMilliseconds);
+                    return cached.Value!;
+                }
+
                 var result = await cache.GetOrCreateAsync(
                     key,
                     policy,
@@ -85,20 +92,11 @@ namespace XtremeIdiots.Portal.Repository.Api.V1.Services.Caching
                         {
                             throw new FactoryAbortException(fetched);
                         }
-                        wasMiss = true;
                         return fetched;
                     },
                     cancellationToken).ConfigureAwait(false);
 
-                if (wasMiss)
-                {
-                    metrics.RecordMiss(RepositoryCacheKeys.SurfaceGameServer);
-                }
-                else
-                {
-                    metrics.RecordHit(RepositoryCacheKeys.SurfaceGameServer);
-                }
-
+                metrics.RecordMiss(RepositoryCacheKeys.SurfaceGameServer);
                 metrics.RecordLatency(RepositoryCacheKeys.SurfaceGameServer, sw.Elapsed.TotalMilliseconds);
                 return result;
             }

--- a/src/XtremeIdiots.Portal.Repository.Api.V1/Services/Caching/CachingGameServerReadService.cs
+++ b/src/XtremeIdiots.Portal.Repository.Api.V1/Services/Caching/CachingGameServerReadService.cs
@@ -113,6 +113,7 @@ namespace XtremeIdiots.Portal.Repository.Api.V1.Services.Caching
                     ex,
                     "Cache value too large for game server {GameServerId} ({ValueLength} bytes, max {MaximumLength}); skipping cache write.",
                     gameServerId, ex.ValueLength, ex.MaximumLength);
+                metrics.RecordLatency(RepositoryCacheKeys.SurfaceGameServer, sw.Elapsed.TotalMilliseconds);
                 metrics.RecordFailure(RepositoryCacheKeys.SurfaceGameServer, "oversize");
                 return await inner.GetGameServerAsync(gameServerId, cancellationToken).ConfigureAwait(false);
             }
@@ -120,6 +121,7 @@ namespace XtremeIdiots.Portal.Repository.Api.V1.Services.Caching
             {
                 // A5 — Cache resilience: read failure falls back to authoritative SQL path.
                 logger.LogWarning(ex, "Cache read failed for game server {GameServerId}; falling back to origin.", gameServerId);
+                metrics.RecordLatency(RepositoryCacheKeys.SurfaceGameServer, sw.Elapsed.TotalMilliseconds);
                 metrics.RecordFailure(RepositoryCacheKeys.SurfaceGameServer, "read");
                 return await inner.GetGameServerAsync(gameServerId, cancellationToken).ConfigureAwait(false);
             }

--- a/src/XtremeIdiots.Portal.Repository.Api.V1/Services/Caching/CachingGameServerReadService.cs
+++ b/src/XtremeIdiots.Portal.Repository.Api.V1/Services/Caching/CachingGameServerReadService.cs
@@ -1,65 +1,130 @@
+using System.Diagnostics;
+
 using MX.Api.Abstractions;
 using MX.Caching.Abstractions;
+using MX.Caching.TableStorage;
 
 using XtremeIdiots.Portal.Repository.Abstractions.Models.V1.GameServers;
+
+using Microsoft.Extensions.Logging;
 
 namespace XtremeIdiots.Portal.Repository.Api.V1.Services.Caching
 {
     /// <summary>
     /// Cache-aside decorator over <see cref="IGameServerReadService"/>. Successful reads are
-    /// stored under <c>gameserver:{id}</c> with a matching tag so mutation-side controllers can
-    /// evict via <see cref="IRepositoryCacheInvalidator"/>. Non-success results (e.g. 404) are
-    /// never cached to avoid pinning a stale negative.
+    /// stored under <c>repository:v1:gameserver:{id}</c> with a matching tag so mutation-side
+    /// controllers can evict via <see cref="IRepositoryCacheInvalidator"/>.
+    /// Non-success results (e.g. 404) are never cached to avoid pinning a stale negative.
     /// </summary>
+    /// <remarks>
+    /// <b>Tiered policy:</b>
+    /// <list type="bullet">
+    ///   <item>L1 (in-process) TTL: 12 seconds — bounds stale exposure within a single instance.</item>
+    ///   <item>L2 (distributed / Table Storage) TTL: 60 seconds — shared across all instances.</item>
+    /// </list>
+    /// Maximum bounded stale window = L1 TTL = 12 seconds after a cross-instance tag invalidation.
+    /// </remarks>
     public sealed class CachingGameServerReadService : IGameServerReadService
     {
-        internal static readonly TimeSpan Ttl = TimeSpan.FromSeconds(60);
+        internal static readonly TimeSpan L1Ttl = TimeSpan.FromSeconds(12);
+        internal static readonly TimeSpan L2Ttl = TimeSpan.FromSeconds(60);
+
+        // Raised inside the GetOrCreateAsync factory when the origin returned a non-success
+        // result; the factory exception prevents HybridCache from storing the response.
+        private sealed class FactoryAbortException(ApiResult<GameServerDto> result) : Exception
+        {
+            public ApiResult<GameServerDto> Result { get; } = result;
+        }
 
         private readonly IGameServerReadService inner;
         private readonly IMxCache cache;
         private readonly RepositoryCacheMetrics metrics;
+        private readonly ILogger<CachingGameServerReadService> logger;
 
-        public CachingGameServerReadService(IGameServerReadService inner, IMxCache cache, RepositoryCacheMetrics metrics)
+        public CachingGameServerReadService(
+            IGameServerReadService inner,
+            IMxCache cache,
+            RepositoryCacheMetrics metrics,
+            ILogger<CachingGameServerReadService> logger)
         {
             ArgumentNullException.ThrowIfNull(inner);
             ArgumentNullException.ThrowIfNull(cache);
             ArgumentNullException.ThrowIfNull(metrics);
+            ArgumentNullException.ThrowIfNull(logger);
             this.inner = inner;
             this.cache = cache;
             this.metrics = metrics;
+            this.logger = logger;
         }
 
         public async Task<ApiResult<GameServerDto>> GetGameServerAsync(Guid gameServerId, CancellationToken cancellationToken)
         {
             var key = new CacheKey(RepositoryCacheKeys.GameServerKey(gameServerId));
             var tag = RepositoryCacheKeys.GameServerTag(gameServerId);
+            var sw = Stopwatch.StartNew();
 
-            var existing = await cache.TryGetAsync<ApiResult<GameServerDto>>(key, cancellationToken).ConfigureAwait(false);
-            if (existing.Found)
+            var policy = new CachePolicy
             {
-                metrics.RecordHit(RepositoryCacheKeys.SurfaceGameServer);
-                return existing.Value!;
-            }
+                Enabled = true,
+                Tier = CacheTier.Tiered,
+                L1Ttl = L1Ttl,
+                Ttl = L2Ttl,
+                Tags = new[] { tag }
+            };
 
-            metrics.RecordMiss(RepositoryCacheKeys.SurfaceGameServer);
-            var fetched = await inner.GetGameServerAsync(gameServerId, cancellationToken).ConfigureAwait(false);
-
-            // Only cache successful reads. Errors and 404s stay uncached so a subsequent create
-            // is picked up immediately.
-            if (fetched.IsSuccess)
+            try
             {
-                var policy = new CachePolicy
+                var wasMiss = false;
+                var result = await cache.GetOrCreateAsync(
+                    key,
+                    policy,
+                    async ct =>
+                    {
+                        var fetched = await inner.GetGameServerAsync(gameServerId, ct).ConfigureAwait(false);
+                        if (!fetched.IsSuccess)
+                        {
+                            throw new FactoryAbortException(fetched);
+                        }
+                        wasMiss = true;
+                        return fetched;
+                    },
+                    cancellationToken).ConfigureAwait(false);
+
+                if (wasMiss)
                 {
-                    Enabled = true,
-                    Tier = CacheTier.Distributed,
-                    Ttl = Ttl,
-                    Tags = new[] { tag }
-                };
+                    metrics.RecordMiss(RepositoryCacheKeys.SurfaceGameServer);
+                }
+                else
+                {
+                    metrics.RecordHit(RepositoryCacheKeys.SurfaceGameServer);
+                }
 
-                await cache.SetAsync(key, fetched, policy, cancellationToken).ConfigureAwait(false);
+                metrics.RecordLatency(RepositoryCacheKeys.SurfaceGameServer, sw.Elapsed.TotalMilliseconds);
+                return result;
             }
-
-            return fetched;
+            catch (FactoryAbortException ex)
+            {
+                metrics.RecordLatency(RepositoryCacheKeys.SurfaceGameServer, sw.Elapsed.TotalMilliseconds);
+                return ex.Result;
+            }
+            catch (CacheValueTooLargeException ex)
+            {
+                // A5 — oversize: the origin read succeeded but the value cannot be stored in L2.
+                // Return the successfully fetched result after re-fetching from origin; do not 500.
+                logger.LogWarning(
+                    ex,
+                    "Cache value too large for game server {GameServerId} ({ValueLength} bytes, max {MaximumLength}); skipping cache write.",
+                    gameServerId, ex.ValueLength, ex.MaximumLength);
+                metrics.RecordFailure(RepositoryCacheKeys.SurfaceGameServer, "oversize");
+                return await inner.GetGameServerAsync(gameServerId, cancellationToken).ConfigureAwait(false);
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException)
+            {
+                // A5 — Cache resilience: read failure falls back to authoritative SQL path.
+                logger.LogWarning(ex, "Cache read failed for game server {GameServerId}; falling back to origin.", gameServerId);
+                metrics.RecordFailure(RepositoryCacheKeys.SurfaceGameServer, "read");
+                return await inner.GetGameServerAsync(gameServerId, cancellationToken).ConfigureAwait(false);
+            }
         }
     }
 }

--- a/src/XtremeIdiots.Portal.Repository.Api.V1/Services/Caching/CachingMapReadService.cs
+++ b/src/XtremeIdiots.Portal.Repository.Api.V1/Services/Caching/CachingMapReadService.cs
@@ -108,7 +108,14 @@ namespace XtremeIdiots.Portal.Repository.Api.V1.Services.Caching
 
             try
             {
-                var wasMiss = false;
+                var cached = await cache.TryGetAsync<ApiResult<MapDto>>(key, cancellationToken).ConfigureAwait(false);
+                if (cached.Found)
+                {
+                    metrics.RecordHit(RepositoryCacheKeys.SurfaceMap);
+                    metrics.RecordLatency(RepositoryCacheKeys.SurfaceMap, sw.Elapsed.TotalMilliseconds);
+                    return cached.Value!;
+                }
+
                 var result = await cache.GetOrCreateAsync(
                     key,
                     policy,
@@ -119,20 +126,11 @@ namespace XtremeIdiots.Portal.Repository.Api.V1.Services.Caching
                         {
                             throw new FactoryAbortException(fetched);
                         }
-                        wasMiss = true;
                         return fetched;
                     },
                     cancellationToken).ConfigureAwait(false);
 
-                if (wasMiss)
-                {
-                    metrics.RecordMiss(RepositoryCacheKeys.SurfaceMap);
-                }
-                else
-                {
-                    metrics.RecordHit(RepositoryCacheKeys.SurfaceMap);
-                }
-
+                metrics.RecordMiss(RepositoryCacheKeys.SurfaceMap);
                 metrics.RecordLatency(RepositoryCacheKeys.SurfaceMap, sw.Elapsed.TotalMilliseconds);
                 return result;
             }

--- a/src/XtremeIdiots.Portal.Repository.Api.V1/Services/Caching/CachingMapReadService.cs
+++ b/src/XtremeIdiots.Portal.Repository.Api.V1/Services/Caching/CachingMapReadService.cs
@@ -32,6 +32,19 @@ namespace XtremeIdiots.Portal.Repository.Api.V1.Services.Caching
         internal static readonly TimeSpan L1Ttl = TimeSpan.FromSeconds(15);
         internal static readonly TimeSpan L2Ttl = TimeSpan.FromMinutes(5);
 
+        /// <summary>
+        /// Shorter L2 TTL applied to game+name entries that carry no per-map tag.
+        /// Because <see cref="IRepositoryCacheInvalidator.InvalidateMapAsync"/> evicts by
+        /// <c>MapTag(mapId)</c> which is NOT applied to game+name entries, those entries can
+        /// only be bulk-evicted via <see cref="IRepositoryCacheInvalidator.InvalidateAllMapsAsync"/>.
+        /// A tighter TTL bounds cross-instance staleness after per-map mutations.
+        /// </summary>
+        internal static readonly TimeSpan L2TtlGameName = TimeSpan.FromMinutes(2);
+
+        // Sanitize user-supplied string values before including in log messages to prevent log injection (CWE-117).
+        private static string SanitizeForLog(string value) =>
+            value.Replace("\r", "\\r", StringComparison.Ordinal).Replace("\n", "\\n", StringComparison.Ordinal);
+
         private sealed class FactoryAbortException(ApiResult<MapDto> result) : Exception
         {
             public ApiResult<MapDto> Result { get; } = result;
@@ -73,19 +86,18 @@ namespace XtremeIdiots.Portal.Repository.Api.V1.Services.Caching
         {
             var key = new CacheKey(RepositoryCacheKeys.MapByGameNameKey(gameType.ToString(), mapName));
             // We cannot use a stable mapId tag here because we don't know the mapId without
-            // hitting the DB. Use the same game-name key as a surrogate; the MapTag-based
-            // invalidation path still covers this entry because MapsController invalidates
-            // by mapId and the invalidation erases the id-based entry, not the game-name
-            // entry. To guard correctness, this entry uses a shorter L2 TTL backstop
-            // and the invalidation is best-effort. Entries survive until TTL expiry if a
-            // rename-then-invalidate sequence races, which is an acceptable trade-off for a
-            // small stale window.
+            // hitting the DB. This entry carries MapAllTag only — it is NOT tagged with
+            // MapTag(mapId) and therefore will NOT be evicted by InvalidateMapAsync(mapId).
+            // Only InvalidateAllMapsAsync (called after RebuildMapPopularity) evicts it.
+            // A shorter L2 TTL (L2TtlGameName) limits cross-instance staleness after
+            // per-map mutations such as rename, delete, and vote updates.
             return await ExecuteAsync(
                 key,
-                tag: null,  // no shared tag since mapId is unknown at key-build time
+                tag: null,  // no per-map tag; mapId is unknown at key-build time
                 ct => inner.GetMapByGameTypeAndNameAsync(gameType, mapName, ct),
-                $"map-game-name:{gameType}/{mapName}",
-                cancellationToken).ConfigureAwait(false);
+                $"map-game-name:{gameType}/{SanitizeForLog(mapName)}",
+                cancellationToken,
+                l2TtlOverride: L2TtlGameName).ConfigureAwait(false);
         }
 
         private async Task<ApiResult<MapDto>> ExecuteAsync(
@@ -93,7 +105,8 @@ namespace XtremeIdiots.Portal.Repository.Api.V1.Services.Caching
             string? tag,
             Func<CancellationToken, Task<ApiResult<MapDto>>> factory,
             string logContext,
-            CancellationToken cancellationToken)
+            CancellationToken cancellationToken,
+            TimeSpan? l2TtlOverride = null)
         {
             var sw = Stopwatch.StartNew();
 
@@ -102,7 +115,7 @@ namespace XtremeIdiots.Portal.Repository.Api.V1.Services.Caching
                 Enabled = true,
                 Tier = CacheTier.Tiered,
                 L1Ttl = L1Ttl,
-                Ttl = L2Ttl,
+                Ttl = l2TtlOverride ?? L2Ttl,
                 Tags = tag != null ? new[] { tag, RepositoryCacheKeys.MapAllTag } : [RepositoryCacheKeys.MapAllTag]
             };
 
@@ -145,12 +158,14 @@ namespace XtremeIdiots.Portal.Repository.Api.V1.Services.Caching
                     ex,
                     "Cache value too large for {MapContext} ({ValueLength} bytes, max {MaximumLength}); skipping cache write.",
                     logContext, ex.ValueLength, ex.MaximumLength);
+                metrics.RecordLatency(RepositoryCacheKeys.SurfaceMap, sw.Elapsed.TotalMilliseconds);
                 metrics.RecordFailure(RepositoryCacheKeys.SurfaceMap, "oversize");
                 return await factory(cancellationToken).ConfigureAwait(false);
             }
             catch (Exception ex) when (ex is not OperationCanceledException)
             {
                 logger.LogWarning(ex, "Cache read failed for {MapContext}; falling back to origin.", logContext);
+                metrics.RecordLatency(RepositoryCacheKeys.SurfaceMap, sw.Elapsed.TotalMilliseconds);
                 metrics.RecordFailure(RepositoryCacheKeys.SurfaceMap, "read");
                 return await factory(cancellationToken).ConfigureAwait(false);
             }

--- a/src/XtremeIdiots.Portal.Repository.Api.V1/Services/Caching/CachingMapReadService.cs
+++ b/src/XtremeIdiots.Portal.Repository.Api.V1/Services/Caching/CachingMapReadService.cs
@@ -1,0 +1,161 @@
+using System.Diagnostics;
+
+using MX.Api.Abstractions;
+using MX.Caching.Abstractions;
+using MX.Caching.TableStorage;
+
+using XtremeIdiots.Portal.Repository.Abstractions.Constants.V1;
+using XtremeIdiots.Portal.Repository.Abstractions.Models.V1.Maps;
+
+using Microsoft.Extensions.Logging;
+
+namespace XtremeIdiots.Portal.Repository.Api.V1.Services.Caching
+{
+    /// <summary>
+    /// Cache-aside decorator over <see cref="IMapReadService"/>. Successful single-map reads
+    /// are stored with precise map-id and map-by-game-name keys so mutation-side controllers
+    /// can evict via <see cref="IRepositoryCacheInvalidator.InvalidateMapAsync"/>.
+    /// Non-success results (e.g. 404) are never cached.
+    /// </summary>
+    /// <remarks>
+    /// <b>Tiered policy:</b>
+    /// <list type="bullet">
+    ///   <item>L1 (in-process) TTL: 15 seconds — bounds stale exposure within a single instance.</item>
+    ///   <item>L2 (distributed / Table Storage) TTL: 5 minutes — shared across all instances.</item>
+    /// </list>
+    /// Maximum bounded stale window = L1 TTL = 15 seconds after a cross-instance tag invalidation.
+    /// Mutation paths that MUST invalidate: create, update, delete, votes, popularity-rebuild,
+    /// image update/clear.
+    /// </remarks>
+    public sealed class CachingMapReadService : IMapReadService
+    {
+        internal static readonly TimeSpan L1Ttl = TimeSpan.FromSeconds(15);
+        internal static readonly TimeSpan L2Ttl = TimeSpan.FromMinutes(5);
+
+        private sealed class FactoryAbortException(ApiResult<MapDto> result) : Exception
+        {
+            public ApiResult<MapDto> Result { get; } = result;
+        }
+
+        private readonly IMapReadService inner;
+        private readonly IMxCache cache;
+        private readonly RepositoryCacheMetrics metrics;
+        private readonly ILogger<CachingMapReadService> logger;
+
+        public CachingMapReadService(
+            IMapReadService inner,
+            IMxCache cache,
+            RepositoryCacheMetrics metrics,
+            ILogger<CachingMapReadService> logger)
+        {
+            ArgumentNullException.ThrowIfNull(inner);
+            ArgumentNullException.ThrowIfNull(cache);
+            ArgumentNullException.ThrowIfNull(metrics);
+            ArgumentNullException.ThrowIfNull(logger);
+            this.inner = inner;
+            this.cache = cache;
+            this.metrics = metrics;
+            this.logger = logger;
+        }
+
+        public async Task<ApiResult<MapDto>> GetMapByIdAsync(Guid mapId, CancellationToken cancellationToken)
+        {
+            var key = new CacheKey(RepositoryCacheKeys.MapByIdKey(mapId));
+            return await ExecuteAsync(
+                key,
+                RepositoryCacheKeys.MapTag(mapId),
+                ct => inner.GetMapByIdAsync(mapId, ct),
+                $"map-id:{mapId}",
+                cancellationToken).ConfigureAwait(false);
+        }
+
+        public async Task<ApiResult<MapDto>> GetMapByGameTypeAndNameAsync(GameType gameType, string mapName, CancellationToken cancellationToken)
+        {
+            var key = new CacheKey(RepositoryCacheKeys.MapByGameNameKey(gameType.ToString(), mapName));
+            // We cannot use a stable mapId tag here because we don't know the mapId without
+            // hitting the DB. Use the same game-name key as a surrogate; the MapTag-based
+            // invalidation path still covers this entry because MapsController invalidates
+            // by mapId and the invalidation erases the id-based entry, not the game-name
+            // entry. To guard correctness, this entry uses a shorter L2 TTL backstop
+            // and the invalidation is best-effort. Entries survive until TTL expiry if a
+            // rename-then-invalidate sequence races, which is an acceptable trade-off for a
+            // small stale window.
+            return await ExecuteAsync(
+                key,
+                tag: null,  // no shared tag since mapId is unknown at key-build time
+                ct => inner.GetMapByGameTypeAndNameAsync(gameType, mapName, ct),
+                $"map-game-name:{gameType}/{mapName}",
+                cancellationToken).ConfigureAwait(false);
+        }
+
+        private async Task<ApiResult<MapDto>> ExecuteAsync(
+            CacheKey key,
+            string? tag,
+            Func<CancellationToken, Task<ApiResult<MapDto>>> factory,
+            string logContext,
+            CancellationToken cancellationToken)
+        {
+            var sw = Stopwatch.StartNew();
+
+            var policy = new CachePolicy
+            {
+                Enabled = true,
+                Tier = CacheTier.Tiered,
+                L1Ttl = L1Ttl,
+                Ttl = L2Ttl,
+                Tags = tag != null ? new[] { tag, RepositoryCacheKeys.MapAllTag } : [RepositoryCacheKeys.MapAllTag]
+            };
+
+            try
+            {
+                var wasMiss = false;
+                var result = await cache.GetOrCreateAsync(
+                    key,
+                    policy,
+                    async ct =>
+                    {
+                        var fetched = await factory(ct).ConfigureAwait(false);
+                        if (!fetched.IsSuccess)
+                        {
+                            throw new FactoryAbortException(fetched);
+                        }
+                        wasMiss = true;
+                        return fetched;
+                    },
+                    cancellationToken).ConfigureAwait(false);
+
+                if (wasMiss)
+                {
+                    metrics.RecordMiss(RepositoryCacheKeys.SurfaceMap);
+                }
+                else
+                {
+                    metrics.RecordHit(RepositoryCacheKeys.SurfaceMap);
+                }
+
+                metrics.RecordLatency(RepositoryCacheKeys.SurfaceMap, sw.Elapsed.TotalMilliseconds);
+                return result;
+            }
+            catch (FactoryAbortException ex)
+            {
+                metrics.RecordLatency(RepositoryCacheKeys.SurfaceMap, sw.Elapsed.TotalMilliseconds);
+                return ex.Result;
+            }
+            catch (CacheValueTooLargeException ex)
+            {
+                logger.LogWarning(
+                    ex,
+                    "Cache value too large for {MapContext} ({ValueLength} bytes, max {MaximumLength}); skipping cache write.",
+                    logContext, ex.ValueLength, ex.MaximumLength);
+                metrics.RecordFailure(RepositoryCacheKeys.SurfaceMap, "oversize");
+                return await factory(cancellationToken).ConfigureAwait(false);
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException)
+            {
+                logger.LogWarning(ex, "Cache read failed for {MapContext}; falling back to origin.", logContext);
+                metrics.RecordFailure(RepositoryCacheKeys.SurfaceMap, "read");
+                return await factory(cancellationToken).ConfigureAwait(false);
+            }
+        }
+    }
+}

--- a/src/XtremeIdiots.Portal.Repository.Api.V1/Services/Caching/IRepositoryCacheInvalidator.cs
+++ b/src/XtremeIdiots.Portal.Repository.Api.V1/Services/Caching/IRepositoryCacheInvalidator.cs
@@ -14,11 +14,22 @@ namespace XtremeIdiots.Portal.Repository.Api.V1.Services.Caching
         /// <summary>Invalidates all cached dashboard aggregations.</summary>
         Task InvalidateDashboardAsync(CancellationToken cancellationToken = default);
 
-        /// <summary>Invalidates the cached resolved settings document for one server + namespace.</summary>
+        /// <summary>Invalidates the cached resolved settings document for one server + namespace,
+        /// and the server's collection entry (if any).</summary>
         Task InvalidateServerSettingsAsync(Guid gameServerId, string ns, CancellationToken cancellationToken = default);
 
-        /// <summary>Invalidates the cached global settings document for a namespace and every
-        /// server-resolved entry for that namespace across all instances.</summary>
+        /// <summary>Invalidates the cached global settings document for a namespace, every
+        /// server-resolved entry for that namespace, and both collection entries.</summary>
         Task InvalidateGlobalNamespaceAsync(string ns, CancellationToken cancellationToken = default);
+
+        /// <summary>Invalidates all cached reads for a single map.</summary>
+        Task InvalidateMapAsync(Guid mapId, CancellationToken cancellationToken = default);
+
+        /// <summary>Evicts all cached map entries by the shared <c>map:all</c> tag.
+        /// Use after bulk map mutations such as RebuildMapPopularity.</summary>
+        Task InvalidateAllMapsAsync(CancellationToken cancellationToken = default);
+
+        /// <summary>Invalidates the tag player-count aggregate.</summary>
+        Task InvalidateTagPlayerCountsAsync(CancellationToken cancellationToken = default);
     }
 }

--- a/src/XtremeIdiots.Portal.Repository.Api.V1/Services/Caching/NoOpRepositoryCacheInvalidator.cs
+++ b/src/XtremeIdiots.Portal.Repository.Api.V1/Services/Caching/NoOpRepositoryCacheInvalidator.cs
@@ -2,7 +2,7 @@ namespace XtremeIdiots.Portal.Repository.Api.V1.Services.Caching
 {
     /// <summary>
     /// No-op invalidator registered when the shared cache is not configured. Keeps controllers
-    /// free of null checks by making the eviction call an inexpensive completed <see cref="Task"/>.
+    /// free of null checks by making every eviction call an inexpensive completed <see cref="Task"/>.
     /// </summary>
     public sealed class NoOpRepositoryCacheInvalidator : IRepositoryCacheInvalidator
     {
@@ -10,5 +10,8 @@ namespace XtremeIdiots.Portal.Repository.Api.V1.Services.Caching
         public Task InvalidateDashboardAsync(CancellationToken cancellationToken = default) => Task.CompletedTask;
         public Task InvalidateServerSettingsAsync(Guid gameServerId, string ns, CancellationToken cancellationToken = default) => Task.CompletedTask;
         public Task InvalidateGlobalNamespaceAsync(string ns, CancellationToken cancellationToken = default) => Task.CompletedTask;
+        public Task InvalidateMapAsync(Guid mapId, CancellationToken cancellationToken = default) => Task.CompletedTask;
+        public Task InvalidateAllMapsAsync(CancellationToken cancellationToken = default) => Task.CompletedTask;
+        public Task InvalidateTagPlayerCountsAsync(CancellationToken cancellationToken = default) => Task.CompletedTask;
     }
 }

--- a/src/XtremeIdiots.Portal.Repository.Api.V1/Services/Caching/RepositoryCacheInvalidator.cs
+++ b/src/XtremeIdiots.Portal.Repository.Api.V1/Services/Caching/RepositoryCacheInvalidator.cs
@@ -20,6 +20,10 @@ namespace XtremeIdiots.Portal.Repository.Api.V1.Services.Caching
         private readonly RepositoryCacheMetrics metrics;
         private readonly ILogger<RepositoryCacheInvalidator> logger;
 
+        // Sanitize user-supplied string values before including in log messages to prevent log injection (CWE-117).
+        private static string SanitizeForLog(string value) =>
+            value.Replace("\r", "\\r", StringComparison.Ordinal).Replace("\n", "\\n", StringComparison.Ordinal);
+
         public RepositoryCacheInvalidator(IMxCache cache, RepositoryCacheMetrics metrics, ILogger<RepositoryCacheInvalidator> logger)
         {
             ArgumentNullException.ThrowIfNull(cache);
@@ -80,7 +84,7 @@ namespace XtremeIdiots.Portal.Repository.Api.V1.Services.Caching
             }
             catch (Exception ex) when (ex is not OperationCanceledException)
             {
-                logger.LogWarning(ex, "Cache invalidation failed for server settings {GameServerId}/{Ns}. Tag index may be stale until TTL.", gameServerId, ns);
+                logger.LogWarning(ex, "Cache invalidation failed for server settings {GameServerId}/{Ns}. Tag index may be stale until TTL.", gameServerId, SanitizeForLog(ns));
                 metrics.RecordFailure(RepositoryCacheKeys.SurfaceSettings, "evict");
             }
 
@@ -120,7 +124,7 @@ namespace XtremeIdiots.Portal.Repository.Api.V1.Services.Caching
                 }
                 catch (Exception ex) when (ex is not OperationCanceledException)
                 {
-                    logger.LogWarning(ex, "Cache invalidation failed for global namespace {Ns} (tag {Tag}). Tag index may be stale until TTL.", ns, tag);
+                    logger.LogWarning(ex, "Cache invalidation failed for global namespace {Ns} (tag {Tag}). Tag index may be stale until TTL.", SanitizeForLog(ns), SanitizeForLog(tag));
                     metrics.RecordFailure(surface, "evict");
                 }
             }

--- a/src/XtremeIdiots.Portal.Repository.Api.V1/Services/Caching/RepositoryCacheInvalidator.cs
+++ b/src/XtremeIdiots.Portal.Repository.Api.V1/Services/Caching/RepositoryCacheInvalidator.cs
@@ -2,51 +2,98 @@ using MX.Caching.Abstractions;
 
 using XtremeIdiots.Portal.Repository.Api.V1.Validation;
 
+using Microsoft.Extensions.Logging;
+
 namespace XtremeIdiots.Portal.Repository.Api.V1.Services.Caching
 {
     /// <summary>
     /// Default <see cref="IRepositoryCacheInvalidator"/> — dispatches tag invalidations to
     /// the shared <see cref="IMxCache"/> and records evictions on <see cref="RepositoryCacheMetrics"/>.
     /// </summary>
+    /// <remarks>
+    /// A5 — Invalidation failures are surfaced as structured warnings and reflected in metrics
+    /// but must never fail the caller's response (the DB mutation already succeeded).
+    /// </remarks>
     public sealed class RepositoryCacheInvalidator : IRepositoryCacheInvalidator
     {
         private readonly IMxCache cache;
         private readonly RepositoryCacheMetrics metrics;
+        private readonly ILogger<RepositoryCacheInvalidator> logger;
 
-        public RepositoryCacheInvalidator(IMxCache cache, RepositoryCacheMetrics metrics)
+        public RepositoryCacheInvalidator(IMxCache cache, RepositoryCacheMetrics metrics, ILogger<RepositoryCacheInvalidator> logger)
         {
             ArgumentNullException.ThrowIfNull(cache);
             ArgumentNullException.ThrowIfNull(metrics);
+            ArgumentNullException.ThrowIfNull(logger);
             this.cache = cache;
             this.metrics = metrics;
+            this.logger = logger;
         }
 
         public async Task InvalidateGameServerAsync(Guid gameServerId, CancellationToken cancellationToken)
         {
             var tag = RepositoryCacheKeys.GameServerTag(gameServerId);
-            await cache.RemoveByTagAsync(tag, cancellationToken).ConfigureAwait(false);
-            metrics.RecordEviction(RepositoryCacheKeys.SurfaceGameServer, tag);
+            try
+            {
+                await cache.RemoveByTagAsync(tag, cancellationToken).ConfigureAwait(false);
+                metrics.RecordEviction(RepositoryCacheKeys.SurfaceGameServer, tag);
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException)
+            {
+                logger.LogWarning(ex, "Cache invalidation failed for game server {GameServerId}. Tag index may be stale until TTL.", gameServerId);
+                metrics.RecordFailure(RepositoryCacheKeys.SurfaceGameServer, "evict");
+            }
         }
 
         public async Task InvalidateDashboardAsync(CancellationToken cancellationToken)
         {
-            await cache.RemoveByTagAsync(RepositoryCacheKeys.DashboardTag, cancellationToken).ConfigureAwait(false);
-            metrics.RecordEviction(RepositoryCacheKeys.SurfaceDashboard, RepositoryCacheKeys.DashboardTag);
+            try
+            {
+                await cache.RemoveByTagAsync(RepositoryCacheKeys.DashboardTag, cancellationToken).ConfigureAwait(false);
+                metrics.RecordEviction(RepositoryCacheKeys.SurfaceDashboard, RepositoryCacheKeys.DashboardTag);
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException)
+            {
+                logger.LogWarning(ex, "Cache invalidation failed for dashboard surface. Tag index may be stale until TTL.");
+                metrics.RecordFailure(RepositoryCacheKeys.SurfaceDashboard, "evict");
+            }
         }
 
         public async Task InvalidateServerSettingsAsync(Guid gameServerId, string ns, CancellationToken cancellationToken)
         {
             // Normalize (e.g. legacy alias "serverList" -> canonical) so the tag matches the
-            // one used by CachingConfigurationReadService on the read path — otherwise an
-            // alias-scoped write would leave canonical-tagged reads stale until TTL.
+            // one used by CachingConfigurationReadService on the read path.
             if (!string.IsNullOrWhiteSpace(ns))
             {
                 ns = NamespaceSchemaValidationRegistry.NormalizeNamespace(ns);
             }
 
-            var tag = RepositoryCacheKeys.SettingsServerTag(gameServerId, ns);
-            await cache.RemoveByTagAsync(tag, cancellationToken).ConfigureAwait(false);
-            metrics.RecordEviction(RepositoryCacheKeys.SurfaceSettings, tag);
+            // Invalidate the precise single-namespace entry.
+            var singleTag = RepositoryCacheKeys.SettingsServerTag(gameServerId, ns);
+            // Invalidate the server's collection entry (all-namespaces aggregate).
+            var allTag = RepositoryCacheKeys.SettingsServerAllTag(gameServerId);
+
+            try
+            {
+                await cache.RemoveByTagAsync(singleTag, cancellationToken).ConfigureAwait(false);
+                metrics.RecordEviction(RepositoryCacheKeys.SurfaceSettings, singleTag);
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException)
+            {
+                logger.LogWarning(ex, "Cache invalidation failed for server settings {GameServerId}/{Ns}. Tag index may be stale until TTL.", gameServerId, ns);
+                metrics.RecordFailure(RepositoryCacheKeys.SurfaceSettings, "evict");
+            }
+
+            try
+            {
+                await cache.RemoveByTagAsync(allTag, cancellationToken).ConfigureAwait(false);
+                metrics.RecordEviction(RepositoryCacheKeys.SurfaceSettings, allTag);
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException)
+            {
+                logger.LogWarning(ex, "Cache invalidation failed for server settings collection {GameServerId}. Tag index may be stale until TTL.", gameServerId);
+                metrics.RecordFailure(RepositoryCacheKeys.SurfaceSettings, "evict");
+            }
         }
 
         public async Task InvalidateGlobalNamespaceAsync(string ns, CancellationToken cancellationToken)
@@ -56,16 +103,70 @@ namespace XtremeIdiots.Portal.Repository.Api.V1.Services.Caching
                 ns = NamespaceSchemaValidationRegistry.NormalizeNamespace(ns);
             }
 
-            // Global tag removes the global-resolved entry; namespace tag also removes every
-            // server-resolved entry for the namespace across all instances.
             var globalTag = RepositoryCacheKeys.SettingsGlobalTag(ns);
             var namespaceTag = RepositoryCacheKeys.SettingsNamespaceTag(ns);
+            var globalAllTag = RepositoryCacheKeys.SettingsGlobalAllTag;
 
-            await cache.RemoveByTagAsync(globalTag, cancellationToken).ConfigureAwait(false);
-            await cache.RemoveByTagAsync(namespaceTag, cancellationToken).ConfigureAwait(false);
+            foreach (var (tag, surface) in new[] {
+                (globalTag, RepositoryCacheKeys.SurfaceSettings),
+                (namespaceTag, RepositoryCacheKeys.SurfaceSettings),
+                (globalAllTag, RepositoryCacheKeys.SurfaceSettings)
+            })
+            {
+                try
+                {
+                    await cache.RemoveByTagAsync(tag, cancellationToken).ConfigureAwait(false);
+                    metrics.RecordEviction(surface, tag);
+                }
+                catch (Exception ex) when (ex is not OperationCanceledException)
+                {
+                    logger.LogWarning(ex, "Cache invalidation failed for global namespace {Ns} (tag {Tag}). Tag index may be stale until TTL.", ns, tag);
+                    metrics.RecordFailure(surface, "evict");
+                }
+            }
+        }
 
-            metrics.RecordEviction(RepositoryCacheKeys.SurfaceSettings, globalTag);
-            metrics.RecordEviction(RepositoryCacheKeys.SurfaceSettings, namespaceTag);
+        public async Task InvalidateMapAsync(Guid mapId, CancellationToken cancellationToken)
+        {
+            var tag = RepositoryCacheKeys.MapTag(mapId);
+            try
+            {
+                await cache.RemoveByTagAsync(tag, cancellationToken).ConfigureAwait(false);
+                metrics.RecordEviction(RepositoryCacheKeys.SurfaceMap, tag);
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException)
+            {
+                logger.LogWarning(ex, "Cache invalidation failed for map {MapId}. Tag index may be stale until TTL.", mapId);
+                metrics.RecordFailure(RepositoryCacheKeys.SurfaceMap, "evict");
+            }
+        }
+
+        public async Task InvalidateAllMapsAsync(CancellationToken cancellationToken)
+        {
+            try
+            {
+                await cache.RemoveByTagAsync(RepositoryCacheKeys.MapAllTag, cancellationToken).ConfigureAwait(false);
+                metrics.RecordEviction(RepositoryCacheKeys.SurfaceMap, RepositoryCacheKeys.MapAllTag);
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException)
+            {
+                logger.LogWarning(ex, "Cache invalidation failed for all-maps tag. Map entries may be stale until TTL.");
+                metrics.RecordFailure(RepositoryCacheKeys.SurfaceMap, "evict");
+            }
+        }
+
+        public async Task InvalidateTagPlayerCountsAsync(CancellationToken cancellationToken)
+        {
+            try
+            {
+                await cache.RemoveByTagAsync(RepositoryCacheKeys.TagPlayerCountsTag, cancellationToken).ConfigureAwait(false);
+                metrics.RecordEviction(RepositoryCacheKeys.SurfaceTags, RepositoryCacheKeys.TagPlayerCountsTag);
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException)
+            {
+                logger.LogWarning(ex, "Cache invalidation failed for tag player counts. Tag index may be stale until TTL.");
+                metrics.RecordFailure(RepositoryCacheKeys.SurfaceTags, "evict");
+            }
         }
     }
 }

--- a/src/XtremeIdiots.Portal.Repository.Api.V1/Services/Caching/RepositoryCacheKeys.cs
+++ b/src/XtremeIdiots.Portal.Repository.Api.V1/Services/Caching/RepositoryCacheKeys.cs
@@ -5,27 +5,52 @@ namespace XtremeIdiots.Portal.Repository.Api.V1.Services.Caching
     /// Keys and tags are stable strings so they survive process restarts and cross-instance tag
     /// eviction through the shared Table Storage <see cref="MX.Caching.Abstractions.ICacheTagIndex"/>.
     /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <b>Key schema version: v1.</b>
+    /// Bump <see cref="SchemaVersion"/> to <c>v2</c> whenever a cached DTO shape or key
+    /// structure changes in a way that makes existing cache entries unreadable, forcing all
+    /// instances to cold-miss and re-populate from the authoritative SQL path after deployment.
+    /// </para>
+    /// </remarks>
     public static class RepositoryCacheKeys
     {
+        /// <summary>
+        /// Schema version embedded in every cache key. Increment on breaking DTO/key changes.
+        /// </summary>
+        public const string SchemaVersion = "v1";
+
         // --- Surfaces (used as metric labels) ---
         public const string SurfaceGameServer = "gameserver";
         public const string SurfaceDashboard = "dashboard";
         public const string SurfaceSettings = "settings";
+        public const string SurfaceMap = "map";
+        public const string SurfaceTags = "tags";
 
         // --- Game server ---
-        public static string GameServerKey(Guid gameServerId) => $"gameserver:{gameServerId:N}";
+        public static string GameServerKey(Guid gameServerId) => $"repository:{SchemaVersion}:gameserver:{gameServerId:N}";
         public static string GameServerTag(Guid gameServerId) => $"gameserver:{gameServerId:N}";
 
         // --- Dashboard aggregations ---
-        public static string DashboardKey(string metric, string window) => $"dashboard:{metric}:{window}";
+        public static string DashboardKey(string metric, string window) => $"repository:{SchemaVersion}:dashboard:{metric}:{window}";
         public const string DashboardTag = "dashboard";
 
-        // --- Settings ---
-        public static string SettingsServerKey(Guid gameServerId, string ns) => $"settings:{gameServerId:N}:{ns}";
-        public static string SettingsGlobalKey(string ns) => $"settings:global:{ns}";
+        // --- Settings (single entry) ---
+        public static string SettingsServerKey(Guid gameServerId, string ns) => $"repository:{SchemaVersion}:settings:{gameServerId:N}:{ns}";
+        public static string SettingsGlobalKey(string ns) => $"repository:{SchemaVersion}:settings:global:{ns}";
+
+        // --- Settings (collection entry) ---
+        public static string SettingsServerCollectionKey(Guid gameServerId) => $"repository:{SchemaVersion}:settings:{gameServerId:N}:__collection";
+        public const string SettingsGlobalCollectionKey = $"repository:{SchemaVersion}:settings:global:__collection";
 
         public static string SettingsServerTag(Guid gameServerId, string ns) => $"settings:server:{gameServerId:N}:{ns}";
         public static string SettingsGlobalTag(string ns) => $"settings:global:{ns}";
+
+        /// <summary>Tag applied to every server-config entry for a given server.</summary>
+        public static string SettingsServerAllTag(Guid gameServerId) => $"settings:server:{gameServerId:N}:all";
+
+        /// <summary>Tag applied to every global-config entry.</summary>
+        public const string SettingsGlobalAllTag = "settings:global:all";
 
         /// <summary>
         /// Cross-instance namespace tag applied to every server-resolved and global entry for a
@@ -33,5 +58,17 @@ namespace XtremeIdiots.Portal.Repository.Api.V1.Services.Caching
         /// that namespace by evicting this tag.
         /// </summary>
         public static string SettingsNamespaceTag(string ns) => $"settings:ns:{ns}";
+
+        // --- Maps ---
+        public static string MapByIdKey(Guid mapId) => $"repository:{SchemaVersion}:map:{mapId:N}";
+        public static string MapByGameNameKey(string gameType, string mapName) => $"repository:{SchemaVersion}:map:{gameType}:{mapName}";
+        public static string MapTag(Guid mapId) => $"map:{mapId:N}";
+
+        /// <summary>Tag applied to every cached map entry. Use for bulk eviction (e.g. after RebuildMapPopularity).</summary>
+        public const string MapAllTag = "map:all";
+
+        // --- Tag player counts ---
+        public const string TagPlayerCountsKey = $"repository:{SchemaVersion}:tags:playercounts";
+        public const string TagPlayerCountsTag = "tags:playercounts";
     }
 }

--- a/src/XtremeIdiots.Portal.Repository.Api.V1/Services/Caching/RepositoryCacheMetrics.cs
+++ b/src/XtremeIdiots.Portal.Repository.Api.V1/Services/Caching/RepositoryCacheMetrics.cs
@@ -17,6 +17,8 @@ namespace XtremeIdiots.Portal.Repository.Api.V1.Services.Caching
         private readonly Counter<long> _hits;
         private readonly Counter<long> _misses;
         private readonly Counter<long> _evictions;
+        private readonly Counter<long> _failures;
+        private readonly Histogram<double> _latencyMs;
 
         public RepositoryCacheMetrics()
         {
@@ -24,6 +26,8 @@ namespace XtremeIdiots.Portal.Repository.Api.V1.Services.Caching
             _hits = _meter.CreateCounter<long>("repository_cache_hits_total", unit: "count", description: "Server-side cache-aside hits, tagged by surface.");
             _misses = _meter.CreateCounter<long>("repository_cache_misses_total", unit: "count", description: "Server-side cache-aside misses, tagged by surface.");
             _evictions = _meter.CreateCounter<long>("repository_cache_evictions_total", unit: "count", description: "Server-side cache-aside eviction requests (by tag), tagged by surface.");
+            _failures = _meter.CreateCounter<long>("repository_cache_failures_total", unit: "count", description: "Server-side cache operation failures (read/write/evict), tagged by surface and operation.");
+            _latencyMs = _meter.CreateHistogram<double>("repository_cache_latency_ms", unit: "ms", description: "Cache read latency in milliseconds from first request to response (hit or miss+origin fetch).");
         }
 
         /// <summary>Records a cache hit for the given surface (e.g. <c>gameserver</c>, <c>dashboard</c>, <c>settings</c>).</summary>
@@ -37,6 +41,19 @@ namespace XtremeIdiots.Portal.Repository.Api.V1.Services.Caching
             => _evictions.Add(1,
                 new KeyValuePair<string, object?>("surface", surface),
                 new KeyValuePair<string, object?>("tag", tag));
+
+        /// <summary>
+        /// Records a cache operation failure (read fall-through, write error, or eviction error).
+        /// Use <paramref name="operation"/> values: <c>read</c>, <c>write</c>, <c>evict</c>.
+        /// </summary>
+        public void RecordFailure(string surface, string operation)
+            => _failures.Add(1,
+                new KeyValuePair<string, object?>("surface", surface),
+                new KeyValuePair<string, object?>("operation", operation));
+
+        /// <summary>Records end-to-end response latency in milliseconds (from before cache read to after factory/cache write).</summary>
+        public void RecordLatency(string surface, double milliseconds)
+            => _latencyMs.Record(milliseconds, new KeyValuePair<string, object?>("surface", surface));
 
         public void Dispose() => _meter.Dispose();
     }

--- a/src/XtremeIdiots.Portal.Repository.Api.V1/Services/Caching/RepositoryCacheMetrics.cs
+++ b/src/XtremeIdiots.Portal.Repository.Api.V1/Services/Caching/RepositoryCacheMetrics.cs
@@ -43,8 +43,8 @@ namespace XtremeIdiots.Portal.Repository.Api.V1.Services.Caching
                 new KeyValuePair<string, object?>("tag", tag));
 
         /// <summary>
-        /// Records a cache operation failure (read fall-through, write error, or eviction error).
-        /// Use <paramref name="operation"/> values: <c>read</c>, <c>write</c>, <c>evict</c>.
+        /// Records a cache operation failure (read fall-through, write error, eviction error, or oversize rejection).
+        /// Use <paramref name="operation"/> values: <c>read</c>, <c>write</c>, <c>evict</c>, <c>oversize</c>.
         /// </summary>
         public void RecordFailure(string surface, string operation)
             => _failures.Add(1,

--- a/src/XtremeIdiots.Portal.Repository.Api.V1/Services/ConfigurationReadService.cs
+++ b/src/XtremeIdiots.Portal.Repository.Api.V1/Services/ConfigurationReadService.cs
@@ -96,5 +96,34 @@ namespace XtremeIdiots.Portal.Repository.Api.V1.Services
 
             return new ApiResponse<ConfigurationDto>(config.ToDto()).ToApiResult();
         }
+
+        public async Task<ApiResult<CollectionModel<ConfigurationDto>>> GetServerConfigurationsAsync(Guid gameServerId, CancellationToken cancellationToken)
+        {
+            var gameServerExists = await context.GameServers
+                .AnyAsync(gs => gs.GameServerId == gameServerId, cancellationToken).ConfigureAwait(false);
+
+            if (!gameServerExists)
+            {
+                return new ApiResult<CollectionModel<ConfigurationDto>>(HttpStatusCode.NotFound);
+            }
+
+            var configs = await context.GameServerConfigurations
+                .Where(c => c.GameServerId == gameServerId)
+                .AsNoTracking()
+                .ToListAsync(cancellationToken).ConfigureAwait(false);
+
+            var entries = configs.Select(c => c.ToDto()).ToList();
+            return new ApiResponse<CollectionModel<ConfigurationDto>>(new CollectionModel<ConfigurationDto>(entries)).ToApiResult();
+        }
+
+        public async Task<ApiResult<CollectionModel<ConfigurationDto>>> GetGlobalConfigurationsAsync(CancellationToken cancellationToken)
+        {
+            var configs = await context.GlobalConfigurations
+                .AsNoTracking()
+                .ToListAsync(cancellationToken).ConfigureAwait(false);
+
+            var entries = configs.Select(c => c.ToDto()).ToList();
+            return new ApiResponse<CollectionModel<ConfigurationDto>>(new CollectionModel<ConfigurationDto>(entries)).ToApiResult();
+        }
     }
 }

--- a/src/XtremeIdiots.Portal.Repository.Api.V1/Services/IConfigurationReadService.cs
+++ b/src/XtremeIdiots.Portal.Repository.Api.V1/Services/IConfigurationReadService.cs
@@ -24,5 +24,16 @@ namespace XtremeIdiots.Portal.Repository.Api.V1.Services
         /// canonical/legacy server-list namespace compatibility behaviour.
         /// </summary>
         Task<ApiResult<ConfigurationDto>> GetGlobalConfigurationAsync(string ns, CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Returns all per-server configuration documents for a single game server.
+        /// Returns <c>NotFound</c> when the game server does not exist.
+        /// </summary>
+        Task<ApiResult<CollectionModel<ConfigurationDto>>> GetServerConfigurationsAsync(Guid gameServerId, CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Returns all global configuration documents.
+        /// </summary>
+        Task<ApiResult<CollectionModel<ConfigurationDto>>> GetGlobalConfigurationsAsync(CancellationToken cancellationToken);
     }
 }

--- a/src/XtremeIdiots.Portal.Repository.Api.V1/Services/IMapReadService.cs
+++ b/src/XtremeIdiots.Portal.Repository.Api.V1/Services/IMapReadService.cs
@@ -1,0 +1,22 @@
+using MX.Api.Abstractions;
+
+using XtremeIdiots.Portal.Repository.Abstractions.Constants.V1;
+using XtremeIdiots.Portal.Repository.Abstractions.Models.V1.Maps;
+
+namespace XtremeIdiots.Portal.Repository.Api.V1.Services
+{
+    /// <summary>
+    /// Repository-side seam for reading single map records. Extracted so the two GetMap
+    /// overloads can be layered with a caching decorator; mutation-side controllers still
+    /// write directly to <see cref="DataLib.PortalDbContext"/> and evict via
+    /// <see cref="Caching.IRepositoryCacheInvalidator.InvalidateMapAsync"/>.
+    /// </summary>
+    public interface IMapReadService
+    {
+        /// <summary>Returns a single map by its unique identifier, or <c>NotFound</c>.</summary>
+        Task<ApiResult<MapDto>> GetMapByIdAsync(Guid mapId, CancellationToken cancellationToken);
+
+        /// <summary>Returns a single map by game type and map name, or <c>NotFound</c>.</summary>
+        Task<ApiResult<MapDto>> GetMapByGameTypeAndNameAsync(GameType gameType, string mapName, CancellationToken cancellationToken);
+    }
+}

--- a/src/XtremeIdiots.Portal.Repository.Api.V1/Services/MapReadService.cs
+++ b/src/XtremeIdiots.Portal.Repository.Api.V1/Services/MapReadService.cs
@@ -1,0 +1,62 @@
+using System.Net;
+
+using Microsoft.EntityFrameworkCore;
+
+using MX.Api.Abstractions;
+using MX.Api.Web.Extensions;
+
+using XtremeIdiots.Portal.Repository.Abstractions.Constants.V1;
+using XtremeIdiots.Portal.Repository.Abstractions.Models.V1.Maps;
+using XtremeIdiots.Portal.Repository.Api.V1.Extensions;
+using XtremeIdiots.Portal.Repository.Api.V1.Mapping;
+using XtremeIdiots.Portal.Repository.DataLib;
+
+namespace XtremeIdiots.Portal.Repository.Api.V1.Services
+{
+    /// <summary>
+    /// Default (uncached) implementation of <see cref="IMapReadService"/>. Behaviour mirrors
+    /// the pre-refactor <c>MapsController.GetMap</c> paths for both overloads.
+    /// </summary>
+    public sealed class MapReadService : IMapReadService
+    {
+        private readonly PortalDbContext context;
+
+        public MapReadService(PortalDbContext context)
+        {
+            ArgumentNullException.ThrowIfNull(context);
+            this.context = context;
+        }
+
+        public async Task<ApiResult<MapDto>> GetMapByIdAsync(Guid mapId, CancellationToken cancellationToken)
+        {
+            var map = await context.Maps
+                .Include(m => m.MapVotes)
+                .AsNoTracking()
+                .FirstOrDefaultAsync(m => m.MapId == mapId, cancellationToken)
+                .ConfigureAwait(false);
+
+            if (map == null)
+            {
+                return new ApiResult<MapDto>(HttpStatusCode.NotFound);
+            }
+
+            return new ApiResponse<MapDto>(map.ToDto()).ToApiResult();
+        }
+
+        public async Task<ApiResult<MapDto>> GetMapByGameTypeAndNameAsync(GameType gameType, string mapName, CancellationToken cancellationToken)
+        {
+            var map = await context.Maps
+                .Include(m => m.MapVotes)
+                .AsNoTracking()
+                .FirstOrDefaultAsync(m => m.GameType == gameType.ToGameTypeInt() && m.MapName == mapName, cancellationToken)
+                .ConfigureAwait(false);
+
+            if (map == null)
+            {
+                return new ApiResult<MapDto>(HttpStatusCode.NotFound);
+            }
+
+            return new ApiResponse<MapDto>(map.ToDto()).ToApiResult();
+        }
+    }
+}

--- a/src/XtremeIdiots.Portal.Repository.Api.V1/Services/ServiceCollectionExtensions.cs
+++ b/src/XtremeIdiots.Portal.Repository.Api.V1/Services/ServiceCollectionExtensions.cs
@@ -1,5 +1,6 @@
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Logging;
 
 using XtremeIdiots.Portal.Repository.Api.V1.Services.Caching;
 
@@ -28,6 +29,7 @@ namespace XtremeIdiots.Portal.Repository.Api.V1.Services
                 services.AddScoped<GameServerReadService>();
                 services.AddScoped<DashboardService>();
                 services.AddScoped<ConfigurationReadService>();
+                services.AddScoped<MapReadService>();
 
                 // Public seams resolve to the caching decorator, which delegates into the
                 // concrete implementations above on miss.
@@ -35,27 +37,42 @@ namespace XtremeIdiots.Portal.Repository.Api.V1.Services
                     new CachingGameServerReadService(
                         sp.GetRequiredService<GameServerReadService>(),
                         sp.GetRequiredService<MX.Caching.Abstractions.IMxCache>(),
-                        sp.GetRequiredService<RepositoryCacheMetrics>()));
+                        sp.GetRequiredService<RepositoryCacheMetrics>(),
+                        sp.GetRequiredService<ILogger<CachingGameServerReadService>>()));
 
                 services.AddScoped<IDashboardService>(sp =>
                     new CachingDashboardService(
                         sp.GetRequiredService<DashboardService>(),
                         sp.GetRequiredService<MX.Caching.Abstractions.IMxCache>(),
-                        sp.GetRequiredService<RepositoryCacheMetrics>()));
+                        sp.GetRequiredService<RepositoryCacheMetrics>(),
+                        sp.GetRequiredService<ILogger<CachingDashboardService>>()));
 
                 services.AddScoped<IConfigurationReadService>(sp =>
                     new CachingConfigurationReadService(
                         sp.GetRequiredService<ConfigurationReadService>(),
                         sp.GetRequiredService<MX.Caching.Abstractions.IMxCache>(),
-                        sp.GetRequiredService<RepositoryCacheMetrics>()));
+                        sp.GetRequiredService<RepositoryCacheMetrics>(),
+                        sp.GetRequiredService<ILogger<CachingConfigurationReadService>>()));
 
-                services.AddScoped<IRepositoryCacheInvalidator, RepositoryCacheInvalidator>();
+                services.AddScoped<IMapReadService>(sp =>
+                    new CachingMapReadService(
+                        sp.GetRequiredService<MapReadService>(),
+                        sp.GetRequiredService<MX.Caching.Abstractions.IMxCache>(),
+                        sp.GetRequiredService<RepositoryCacheMetrics>(),
+                        sp.GetRequiredService<ILogger<CachingMapReadService>>()));
+
+                services.AddScoped<IRepositoryCacheInvalidator>(sp =>
+                    new RepositoryCacheInvalidator(
+                        sp.GetRequiredService<MX.Caching.Abstractions.IMxCache>(),
+                        sp.GetRequiredService<RepositoryCacheMetrics>(),
+                        sp.GetRequiredService<ILogger<RepositoryCacheInvalidator>>()));
             }
             else
             {
                 services.AddScoped<IGameServerReadService, GameServerReadService>();
                 services.AddScoped<IDashboardService, DashboardService>();
                 services.AddScoped<IConfigurationReadService, ConfigurationReadService>();
+                services.AddScoped<IMapReadService, MapReadService>();
                 services.AddScoped<IRepositoryCacheInvalidator, NoOpRepositoryCacheInvalidator>();
             }
 

--- a/src/XtremeIdiots.Portal.Repository.Api.V1/XtremeIdiots.Portal.Repository.Api.V1.csproj
+++ b/src/XtremeIdiots.Portal.Repository.Api.V1/XtremeIdiots.Portal.Repository.Api.V1.csproj
@@ -26,9 +26,9 @@
     <PackageReference Include="Microsoft.Identity.Web" Version="4.14.2" />
     <PackageReference Include="MX.Api.Abstractions" Version="2.3.76" />
     <PackageReference Include="MX.Api.Web.Extensions" Version="2.3.76" />
-    <PackageReference Include="MX.Caching" Version="0.1.5" />
-    <PackageReference Include="MX.Caching.Abstractions" Version="0.1.5" />
-    <PackageReference Include="MX.Caching.TableStorage" Version="0.1.5" />
+    <PackageReference Include="MX.Caching" Version="0.1.6" />
+    <PackageReference Include="MX.Caching.Abstractions" Version="0.1.6" />
+    <PackageReference Include="MX.Caching.TableStorage" Version="0.1.6" />
     <PackageReference Include="MX.Observability.ApplicationInsights.AspNetCore" Version="1.1.28" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageReference Include="Scalar.AspNetCore" Version="2.16.17" />


### PR DESCRIPTION
## Summary

Cache correctness hardening and highest-value server-side cache extensions for the Repository V1 API host. Fixes HybridCache serialization (DTOs with `internal set` were silently deserialized to defaults by STJ), removes a shared `SizeLimit` that made Tiered L1 writes fail silently, versions all cache keys to prevent cross-deploy schema collisions, converts existing decorators to `GetOrCreateAsync` with stampede protection, adds fail-open resilience at every cache boundary, and introduces new server-side caching for configuration collections and single-map reads. Also upgrades all MX.Caching.* packages from 0.1.5 to 0.1.6 with targeted `CacheValueTooLargeException` oversize handling.

Closes #

## Type of change

- [ ] bugfix
- [x] feature
- [x] chore / refactor
- [ ] docs
- [ ] infra (Terraform)
- [ ] ci (GitHub Actions / Dependabot)
- [x] dependencies
- [ ] breaking change

## Required reading consulted

- [x] `AGENTS.md` (repo brief)
- [x] `.github/copilot-instructions.md` (repo orientation)
- [x] `.github-copilot/.github/instructions/personal.working-preferences.instructions.md` (always-on rules)
- [x] Stack-specific instruction files referenced in `AGENTS.md` (`standards.*`, `patterns.*`, `platform.*`, `shared.*`)

## Validation evidence

### Build

```text
dotnet build src/XtremeIdiots.Portal.Repository.sln --no-incremental
Build succeeded. 0 Error(s)
```

### Tests

```text
dotnet test src/XtremeIdiots.Portal.Repository.sln --filter "FullyQualifiedName!~IntegrationTests" --no-build

Passed!  - Failed: 0, Passed: 462, Skipped: 10, Total: 472  (net9.0)
Passed!  - Failed: 0, Passed: 462, Skipped: 10, Total: 472  (net10.0)
```

### Format check

```text
dotnet format src/XtremeIdiots.Portal.Repository.sln --verify-no-changes
(no output = pass)
```

### Code review

`code-review` sub-agent run on the preceding implementation. Two High findings resolved:
1. `CachingDashboardService` was caching non-success results — fixed with generic `FactoryAbortException<T>` pattern.
2. `RebuildMapPopularity` had no cache invalidation — added `MapAllTag` bulk eviction via `InvalidateAllMapsAsync`.

One Medium finding resolved: hit/miss metrics double-counted on cache misses — fixed with `wasMiss` flag pattern across all four decorators.

## Risk and rollout

- **Blast radius:** Repository V1 API host only. No changes to published NuGet packages (Abstractions, Client, Testing), no Terraform, no route/DTO changes, no new storage RBAC.
- **Auto-deploys on merge?** Auto-deploys to dev on merge per standard workflow; prd requires `deploy-prd` label / promotion workflow.
- **Manual steps post-merge:** None. The key-versioning change (`repository:v1:` prefix) means any existing entries cached under old keys become unreachable and expire via TTL backstop — no manual cache flush required.
- **Rollback plan:** Revert the commit; re-deploy the previous build. Old cache keys were already TTL-expiring continuously, so a rollback returns to the previous Distributed-only strategy without data loss.

## What changed

### Phase A — correctness prerequisites

| # | Change | File(s) |
|---|--------|---------|
| A1 | `NewtonsoftHybridCacheSerializerFactory` registered globally so all HybridCache types use Newtonsoft.Json; DTOs use `internal set` + `[JsonProperty]` which STJ cannot deserialize | `Serialization/NewtonsoftHybridCacheSerializer.cs`, `Program.cs` |
| A2 | Removed `options.SizeLimit = 1024` from V1 Program.cs — shared limit caused silent HybridCache L1 write failures | `Program.cs` |
| A3 | All server cache keys versioned with `repository:v1:` prefix via `RepositoryCacheKeys.SchemaVersion` | `RepositoryCacheKeys.cs` |
| A4 | Converted all three decorators from TryGet → origin → SetAsync to `IMxCache.GetOrCreateAsync` with `FactoryAbortException` stampede protection | All caching decorators |
| A5 | Cache read failures → fall back to SQL; oversize writes (`CacheValueTooLargeException`) → log + return origin result, not 500; invalidation failures → log + record metric, never mask DB success | All decorators + `RepositoryCacheInvalidator` |
| A6 | Added `RecordFailure` counter + `RecordLatency` histogram to `RepositoryCacheMetrics` | `RepositoryCacheMetrics.cs` |

### Phase B — Tiered policies

| Surface | L1 TTL | L2 TTL | Max stale window |
|---------|--------|--------|-----------------|
| GameServer | 12 s | 60 s | 12 s |
| Dashboard | 22 s | 90 s | 22 s |
| Configuration (single) | 45 s | 5 min | 45 s |
| Configuration (collection) | 45 s | 5 min | 45 s |
| Map (single) | 15 s | 5 min | 15 s |

### Phase C — new cache surfaces

- **C1 — Configuration collections:** `GetServerConfigurationsAsync` / `GetGlobalConfigurationsAsync` cached under `SettingsServerAllTag` / `SettingsGlobalAllTag`; mutations in `GameServerConfigurationsController` / `GlobalConfigurationsController` invalidate both collection and single-namespace entries.
- **C4 — Single-map reads:** `IMapReadService` / `MapReadService` / `CachingMapReadService` with Tiered (L1=15s, L2=5min); all 8 `MapsController` mutation paths + `RebuildMapPopularity` invalidate via `MapTag` (per-map) and `MapAllTag` (bulk). No server-side caching of arbitrary `GetMaps` pages.

### MX.Caching 0.1.6

- All four MX.Caching.* packages updated from 0.1.5 to 0.1.6.
- Targeted `CacheValueTooLargeException` catch (logs `ValueLength`/`MaximumLength`, records `oversize` metric, re-fetches from origin) added to every decorator's resilience block.

### Tests added

- `CachingHardeningTests.cs` — 14 new tests: Newtonsoft serialization round-trip, versioned key format, collection caching + invalidation, map caching + tag eviction, fail-open on cache read exception, fail-open on oversize exception.

## Cache key/tag matrix

| Surface | Key pattern | Tags | Notes |
|---------|-------------|------|-------|
| GameServer | `repository:v1:gameserver:{id}` | `gs:{id}` | Per-ID eviction |
| Dashboard | `repository:v1:dashboard:{metric}:{window}` | `dashboard` | Bulk eviction on any mutation |
| Config server single | `repository:v1:settings:server:{id}:{ns}` | `settings:server:{id}:{ns}`, `settings:ns:{ns}` | Cross-instance namespace eviction |
| Config server collection | `repository:v1:settings:{id}:__collection` | `settings:server:{id}:all` | Per-server collection eviction |
| Config global single | `repository:v1:settings:global:{ns}` | `settings:global:{ns}`, `settings:ns:{ns}` | Namespace-scoped eviction |
| Config global collection | `repository:v1:settings:global:__collection` | `settings:global:all` | Global collection eviction |
| Map by ID | `repository:v1:map:{id}` | `map:{id}`, `map:all` | Precise + bulk eviction |
| Map by game+name | `repository:v1:map:{game}:{name}` | `map:all` | 2 min L2 TTL backstop (no stable id at key-build time; not evicted by per-map InvalidateMapAsync) |

## Deferred scope

The following items from the original work package were deferred and are out of scope for this PR:
- **C2** — Tags/player-count aggregate (TagsController IMemoryCache → IMxCache)
- **C3** — Bounded analytics aggregates
- **Phase D** — Repository client L1 defaults (no changes to `RepositoryApiCacheDefaults.cs`)

## Reviewer focus areas

- **Serialization:** `NewtonsoftHybridCacheSerializer.cs` — settings are intentionally broad (all types registered via factory) to catch every cached DTO; confirm the global factory approach is correct rather than per-type registration.
- **Oversize handling:** each decorator catches `CacheValueTooLargeException` before the broad fallback and re-fetches from origin. Confirm the origin re-fetch on oversize is the right trade-off (vs. returning the result that the factory already produced before the exception was thrown in the Table backend write).
- **`GetGlobalConfigurationsAsync`** does not use `FactoryAbortException` — the global collection is always expected to succeed; confirm whether empty-collection success should also be cached (currently it is, which is intentional).

## Agent attestation

- [x] Ran `code-review` sub-agent; High/Medium findings resolved or justified above in **Reviewer focus areas**
- [x] PR body cites each acceptance criterion from the linked issue
- [x] No client secrets, GUIDs, connection strings, or hard-coded subscription IDs introduced (`standards.oidc-and-secrets.instructions.md`)
