### PR TITLE
client: consume MX.Api.Client 2.3.77 SharedCacheConfiguration, remove reflection

### DIFF
--- a/src/XtremeIdiots.Portal.Repository.Abstractions.V1/XtremeIdiots.Portal.Repository.Abstractions.V1.csproj
+++ b/src/XtremeIdiots.Portal.Repository.Abstractions.V1/XtremeIdiots.Portal.Repository.Abstractions.V1.csproj
@@ -25,7 +25,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="MX.Api.Abstractions" Version="2.3.76" />
+    <PackageReference Include="MX.Api.Abstractions" Version="2.3.77" />
     <PackageReference Include="MX.GeoLocation.Abstractions.V1" Version="1.2.96" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
   </ItemGroup>

--- a/src/XtremeIdiots.Portal.Repository.Abstractions.V2/XtremeIdiots.Portal.Repository.Abstractions.V2.csproj
+++ b/src/XtremeIdiots.Portal.Repository.Abstractions.V2/XtremeIdiots.Portal.Repository.Abstractions.V2.csproj
@@ -25,7 +25,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="MX.Api.Abstractions" Version="2.3.76" />
+    <PackageReference Include="MX.Api.Abstractions" Version="2.3.77" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
   </ItemGroup>
 

--- a/src/XtremeIdiots.Portal.Repository.Api.Client.Testing/XtremeIdiots.Portal.Repository.Api.Client.Testing.csproj
+++ b/src/XtremeIdiots.Portal.Repository.Api.Client.Testing/XtremeIdiots.Portal.Repository.Api.Client.Testing.csproj
@@ -15,7 +15,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="MX.Api.Abstractions" Version="2.3.76" />
+		<PackageReference Include="MX.Api.Abstractions" Version="2.3.77" />
 		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.10" />
 	</ItemGroup>
 

--- a/src/XtremeIdiots.Portal.Repository.Api.Client.Tests.V1/RepositoryClientRegistrationTests.cs
+++ b/src/XtremeIdiots.Portal.Repository.Api.Client.Tests.V1/RepositoryClientRegistrationTests.cs
@@ -194,6 +194,30 @@ namespace XtremeIdiots.Portal.Repository.Api.Client.Tests.V1
             }
         }
 
+        /// <summary>
+        /// Guard for the shared cache configuration's <c>ValidateAllOperationsMatched()</c> gate:
+        /// a consumer cache expression targeting an interface that is NOT one of the registered
+        /// Repository sub-APIs must surface as an <see cref="InvalidOperationException"/> at
+        /// registration time, not silently swallowed. This catches consumer typos (wrong interface,
+        /// stale contract reference) instead of leaving them as invisible dead policies.
+        /// </summary>
+        [Fact]
+        public void AddRepositoryApiClient_ConsumerOverrideTargetingUnregisteredInterface_ThrowsValidationError()
+        {
+            var services = new ServiceCollection();
+
+            var ex = Assert.Throws<InvalidOperationException>(() =>
+                services.AddRepositoryApiClient(o => o
+                    .WithBaseUrl(BaseUrl)
+                    .WithApiKeyAuthentication(SubscriptionKey)
+                    .WithCachePartition(CachePartition)
+                    .WithCaching(c => c
+                        .NotCached<INotARegisteredRepositoryApi, Task<ApiResult>>(
+                            x => x.Ping(default)))));
+
+            Assert.NotNull(ex);
+        }
+
         public static TheoryData<Type> AllSubApiInterfaces()
         {
             var data = new TheoryData<Type>();
@@ -248,5 +272,15 @@ namespace XtremeIdiots.Portal.Repository.Api.Client.Tests.V1
             services.AddRepositoryApiClient(configureOptions);
             return services.BuildServiceProvider();
         }
+    }
+
+    /// <summary>
+    /// Fake interface never registered by <see cref="ServiceCollectionExtensions.AddRepositoryApiClient"/>.
+    /// Used to prove that <c>SharedCacheConfiguration.ValidateAllOperationsMatched()</c> surfaces an error
+    /// when a consumer cache expression can never bind to any registered typed sub-API.
+    /// </summary>
+    public interface INotARegisteredRepositoryApi
+    {
+        Task<ApiResult> Ping(CancellationToken cancellationToken);
     }
 }

--- a/src/XtremeIdiots.Portal.Repository.Api.Client.Tests.V1/RepositoryClientRegistrationTests.cs
+++ b/src/XtremeIdiots.Portal.Repository.Api.Client.Tests.V1/RepositoryClientRegistrationTests.cs
@@ -1,0 +1,256 @@
+using System;
+using System.Linq;
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Threading.Tasks;
+
+using Microsoft.Extensions.DependencyInjection;
+
+using MX.Api.Abstractions;
+using MX.Api.Client.Configuration;
+
+using XtremeIdiots.Portal.Repository.Abstractions.Interfaces.V1;
+using XtremeIdiots.Portal.Repository.Abstractions.Models.V1.GameServers;
+using XtremeIdiots.Portal.Repository.Api.Client.V1;
+
+namespace XtremeIdiots.Portal.Repository.Api.Client.Tests.V1
+{
+    /// <summary>
+    /// Startup-time DI resolution tests for <see cref="ServiceCollectionExtensions.AddRepositoryApiClient"/>.
+    /// These tests exercise the full registration path so any regression in cache-policy scoping
+    /// or per-typed-client wiring surfaces at build-provider / resolve time - the same way it does
+    /// in production consumers.
+    /// </summary>
+    public class RepositoryClientRegistrationTests
+    {
+        private const string BaseUrl = "https://repo.example.local";
+        private const string CachePartition = "unit-tests";
+        private const string SubscriptionKey = "test-subscription-key";
+
+        [Fact]
+        public void AddRepositoryApiClient_WithLibraryCacheDefaults_ResolvesUnifiedClient()
+        {
+            using var provider = BuildProvider(o => o
+                .WithBaseUrl(BaseUrl)
+                .WithApiKeyAuthentication(SubscriptionKey)
+                .WithCachePartition(CachePartition)
+                .WithCaching(c => c.UseLibraryDefaults()));
+
+            using var scope = provider.CreateScope();
+
+            var client = scope.ServiceProvider.GetRequiredService<IRepositoryApiClient>();
+            Assert.NotNull(client);
+        }
+
+        /// <summary>
+        /// Repro for the production crash: enabling <c>UseLibraryDefaults()</c> registers the same
+        /// consumer <c>configureOptions</c> delegate against every typed sub-API. Any typed client
+        /// whose <c>SubApiInterface</c> does not match the expressions in the delegate causes
+        /// <see cref="ArgumentException"/> at registration time.
+        /// Resolving <c>IAdminActionsApi</c> should not throw.
+        /// </summary>
+        [Theory]
+        [MemberData(nameof(AllSubApiInterfaces))]
+        public void AddRepositoryApiClient_ResolvesEverySubApi(Type subApiInterface)
+        {
+            using var provider = BuildProvider(o => o
+                .WithBaseUrl(BaseUrl)
+                .WithApiKeyAuthentication(SubscriptionKey)
+                .WithCachePartition(CachePartition)
+                .WithCaching(c => c.UseLibraryDefaults()));
+
+            using var scope = provider.CreateScope();
+
+            var resolved = scope.ServiceProvider.GetService(subApiInterface);
+            Assert.NotNull(resolved);
+        }
+
+        /// <summary>
+        /// The consumer must be able to add a scope-specific override (e.g. a longer TTL for a
+        /// single game-servers list call) on top of <c>UseLibraryDefaults()</c>. That expression
+        /// targets a specific sub-API - it must not fail because the same delegate is replayed
+        /// for other typed clients.
+        /// </summary>
+        [Fact]
+        public void AddRepositoryApiClient_ConsumerOverrideForOneSubApi_DoesNotBleedIntoOthers()
+        {
+            using var provider = BuildProvider(o => o
+                .WithBaseUrl(BaseUrl)
+                .WithApiKeyAuthentication(SubscriptionKey)
+                .WithCachePartition(CachePartition)
+                .WithCaching(c => c
+                    .UseLibraryDefaults()
+                    .NotCached<IGameServersApi, Task<ApiResult<GameServerDto>>>(
+                        x => x.GetGameServer(default, default))));
+
+            using var scope = provider.CreateScope();
+
+            Assert.NotNull(scope.ServiceProvider.GetService<IGameServersApi>());
+            Assert.NotNull(scope.ServiceProvider.GetService<IAdminActionsApi>());
+            Assert.NotNull(scope.ServiceProvider.GetService<IMapsApi>());
+            Assert.NotNull(scope.ServiceProvider.GetService<IUserProfileApi>());
+            Assert.NotNull(scope.ServiceProvider.GetService<IApiInfoApi>());
+            Assert.NotNull(scope.ServiceProvider.GetService<IApiHealthApi>());
+        }
+
+        /// <summary>
+        /// The scoping fix must land the consumer's expression only in the matching typed
+        /// client's Options. Every sibling sub-API's Options should carry
+        /// <c>UseLibraryCacheDefaults</c> but no cross-client policy operations.
+        /// </summary>
+        [Fact]
+        public void AddRepositoryApiClient_ConsumerOverride_AppliesOnlyToMatchingTypedClient()
+        {
+            var services = new ServiceCollection();
+            services.AddRepositoryApiClient(o => o
+                .WithBaseUrl(BaseUrl)
+                .WithApiKeyAuthentication(SubscriptionKey)
+                .WithCachePartition(CachePartition)
+                .WithCaching(c => c
+                    .UseLibraryDefaults()
+                    .NotCached<IGameServersApi, Task<ApiResult<GameServerDto>>>(
+                        x => x.GetGameServer(default, default))));
+
+            using var provider = services.BuildServiceProvider();
+
+            var gameServersOptions = provider.GetRequiredService<RepositoryApiClientOptions>();
+            Assert.True(gameServersOptions.UseLibraryCacheDefaults);
+
+            // All RepositoryApiClientOptions instances are registered as singletons - one per typed client.
+            // Confirm every typed client got its own options and only *some* have the override.
+            var allOptionsInstances = services
+                .Where(sd => sd.ServiceType == typeof(RepositoryApiClientOptions) && sd.ImplementationInstance is not null)
+                .Select(sd => (RepositoryApiClientOptions)sd.ImplementationInstance!)
+                .ToList();
+
+            Assert.True(allOptionsInstances.Count > 5, "Expected one RepositoryApiClientOptions per typed sub-API registration.");
+
+            // Every typed client should honour library defaults.
+            Assert.All(allOptionsInstances, o => Assert.True(o.UseLibraryCacheDefaults));
+
+            // Exactly one of the options instances should carry the consumer override targeting IGameServersApi.GetGameServer.
+            var instancesWithOverride = allOptionsInstances
+                .Where(o => o.CachePolicyOperations.Keys.Any(m =>
+                    m.DeclaringType == typeof(IGameServersApi) && m.Name == nameof(IGameServersApi.GetGameServer)))
+                .ToList();
+
+            Assert.Single(instancesWithOverride);
+
+            // No options instance should carry expressions targeting an interface it isn't for
+            // - this is the crash guard: the override must not have been replayed against other typed clients.
+            Assert.All(allOptionsInstances, o =>
+            {
+                foreach (var method in o.CachePolicyOperations.Keys)
+                {
+                    Assert.Equal(typeof(IGameServersApi), method.DeclaringType);
+                }
+            });
+        }
+
+        [Fact]
+        public void AddRepositoryApiClient_MultipleConsumerOverridesAcrossSubApis_AllApplyToMatchingClientsOnly()
+        {
+            var services = new ServiceCollection();
+            services.AddRepositoryApiClient(o => o
+                .WithBaseUrl(BaseUrl)
+                .WithApiKeyAuthentication(SubscriptionKey)
+                .WithCachePartition(CachePartition)
+                .WithCaching(c => c
+                    .UseLibraryDefaults()
+                    .NotCached<IGameServersApi, Task<ApiResult<GameServerDto>>>(
+                        x => x.GetGameServer(default, default))
+                    .NotCached<IAdminActionsApi, Task<ApiResult>>(
+                        x => x.CreateAdminAction(default!, default))));
+
+            using var provider = services.BuildServiceProvider();
+
+            var allOptionsInstances = services
+                .Where(sd => sd.ServiceType == typeof(RepositoryApiClientOptions) && sd.ImplementationInstance is not null)
+                .Select(sd => (RepositoryApiClientOptions)sd.ImplementationInstance!)
+                .ToList();
+
+            // Each expression must land in exactly one typed client's Options.
+            var gameServersOverrideCount = allOptionsInstances.Count(o => o.CachePolicyOperations.Keys.Any(m =>
+                m.DeclaringType == typeof(IGameServersApi) && m.Name == nameof(IGameServersApi.GetGameServer)));
+            Assert.Equal(1, gameServersOverrideCount);
+
+            var adminActionsOverrideCount = allOptionsInstances.Count(o => o.CachePolicyOperations.Keys.Any(m =>
+                m.DeclaringType == typeof(IAdminActionsApi)));
+            Assert.Equal(1, adminActionsOverrideCount);
+        }
+
+        [Fact]
+        public void AddRepositoryApiClient_WithoutCaching_ResolvesEverySubApi()
+        {
+            using var provider = BuildProvider(o => o
+                .WithBaseUrl(BaseUrl)
+                .WithApiKeyAuthentication(SubscriptionKey));
+
+            using var scope = provider.CreateScope();
+
+            foreach (var subApi in SubApiInterfaces())
+            {
+                var resolved = scope.ServiceProvider.GetService(subApi);
+                Assert.NotNull(resolved);
+            }
+        }
+
+        public static TheoryData<Type> AllSubApiInterfaces()
+        {
+            var data = new TheoryData<Type>();
+            foreach (var type in SubApiInterfaces())
+            {
+                data.Add(type);
+            }
+            return data;
+        }
+
+        private static IEnumerable<Type> SubApiInterfaces() => new[]
+        {
+            typeof(IAdminActionsApi),
+            typeof(IBanFileMonitorsApi),
+            typeof(ICentralBanFileStatusApi),
+            typeof(IChatMessagesApi),
+            typeof(IDataMaintenanceApi),
+            typeof(IDemosApi),
+            typeof(IGameServersApi),
+            typeof(IGameServersEventsApi),
+            typeof(IGameServersStatsApi),
+            typeof(IGameTrackerBannerApi),
+            typeof(IMapsApi),
+            typeof(IConnectedPlayersApi),
+            typeof(IPlayerAnalyticsApi),
+            typeof(IPlayersApi),
+            typeof(IRecentPlayersApi),
+            typeof(IReportsApi),
+            typeof(ITagsApi),
+            typeof(IUserProfileApi),
+            typeof(IApiInfoApi),
+            typeof(IApiHealthApi),
+            typeof(INotificationTypesApi),
+            typeof(INotificationPreferencesApi),
+            typeof(INotificationsApi),
+            typeof(IMapRotationsApi),
+            typeof(IDashboardApi),
+            typeof(IGlobalConfigurationsApi),
+            typeof(IGameServerConfigurationsApi),
+            typeof(ILiveStatusApi),
+            typeof(IGlobalAnalyticsApi),
+            typeof(IGameAnalyticsApi),
+            typeof(IServerAnalyticsApi),
+            typeof(IDashboardAnalyticsApi),
+            typeof(IMapAnalyticsApi),
+            typeof(IPlayerAnalyticsV2Api),
+        };
+
+        private static ServiceProvider BuildProvider(Action<RepositoryApiOptionsBuilder> configureOptions)
+        {
+            var services = new ServiceCollection();
+            services.AddRepositoryApiClient(configureOptions);
+            return services.BuildServiceProvider();
+        }
+    }
+}

--- a/src/XtremeIdiots.Portal.Repository.Api.Client.Tests.V1/RepositoryClientRegistrationTests.cs
+++ b/src/XtremeIdiots.Portal.Repository.Api.Client.Tests.V1/RepositoryClientRegistrationTests.cs
@@ -1,10 +1,6 @@
 using System;
-using System.Linq;
-
-using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Reflection;
 using System.Threading.Tasks;
 
 using Microsoft.Extensions.DependencyInjection;

--- a/src/XtremeIdiots.Portal.Repository.Api.Client.V1/RepositoryApiOptionsBuilder.cs
+++ b/src/XtremeIdiots.Portal.Repository.Api.Client.V1/RepositoryApiOptionsBuilder.cs
@@ -1,6 +1,4 @@
 using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Reflection;
 
 using MX.Api.Client.Configuration;

--- a/src/XtremeIdiots.Portal.Repository.Api.Client.V1/RepositoryApiOptionsBuilder.cs
+++ b/src/XtremeIdiots.Portal.Repository.Api.Client.V1/RepositoryApiOptionsBuilder.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Reflection;
 
 using MX.Api.Client.Configuration;
 
@@ -10,6 +9,16 @@ namespace XtremeIdiots.Portal.Repository.Api.Client.V1
     /// </summary>
     public class RepositoryApiOptionsBuilder : ApiClientOptionsBuilder<RepositoryApiClientOptions, RepositoryApiOptionsBuilder>
     {
+        /// <summary>
+        /// Cache configuration delegate captured from a consumer <see cref="WithCaching(Action{CacheBuilder})"/> call.
+        /// </summary>
+        /// <remarks>
+        /// Applied per typed sub-API by <see cref="ServiceCollectionExtensions.AddRepositoryApiClient"/> via a single
+        /// <see cref="SharedCacheConfiguration"/> instance and <c>WithSharedCaching</c>, which scopes operations to
+        /// the currently-configured typed client. See also <see cref="ServiceCollectionExtensions"/> for orchestration.
+        /// </remarks>
+        internal Action<CacheBuilder>? CapturedCacheConfigure { get; private set; }
+
         /// <summary>
         /// Creates a new instance of the RepositoryApiOptionsBuilder
         /// </summary>
@@ -38,25 +47,26 @@ namespace XtremeIdiots.Portal.Repository.Api.Client.V1
         }
 
         /// <summary>
-        /// Configures caching for the Repository API client with cross-sub-API scope isolation.
+        /// Captures a caching configuration delegate for cross-sub-API application.
         /// </summary>
         /// <remarks>
         /// <para>
-        /// The <see cref="ServiceCollectionExtensions.AddRepositoryApiClient"/> registration
-        /// re-invokes the consumer's configuration delegate once per typed sub-API
-        /// (<see cref="Abstractions.Interfaces.V1.IAdminActionsApi"/>,
-        /// <see cref="Abstractions.Interfaces.V1.IGameServersApi"/>, etc.). MX.Api.Client 2.3.76
-        /// scopes each builder to a single typed client, so an expression such as
+        /// <see cref="ServiceCollectionExtensions.AddRepositoryApiClient"/> re-invokes the consumer's configuration
+        /// delegate once per typed sub-API (<see cref="Abstractions.Interfaces.V1.IAdminActionsApi"/>,
+        /// <see cref="Abstractions.Interfaces.V1.IGameServersApi"/>, etc.). The base
+        /// <see cref="ApiClientOptionsBuilder{TOptions,TBuilder}.WithCaching(Action{CacheBuilder})"/> scopes each call to
+        /// a single typed client, so an expression such as
         /// <c>c.NotCached&lt;IGameServersApi, ...&gt;(x =&gt; x.GetGameServer(...))</c> would throw
         /// <see cref="ArgumentException"/> when replayed against every non-matching typed client.
         /// </para>
         /// <para>
-        /// This override captures the consumer's intent once against an unscoped shadow builder,
-        /// then replays only the operations whose declaring interface is assignable to the
-        /// currently-configured typed client, preserving library-default opt-in and consumer
-        /// overrides while eliminating the cross-client crash. Library defaults registered via
-        /// <see cref="MX.Api.Client.Extensions.ApiClientExtensions.AddDefaultCachePolicies{TClient}"/>
-        /// continue to apply per typed client as designed.
+        /// This override captures the delegate on <see cref="CapturedCacheConfigure"/> without applying it.
+        /// <see cref="ServiceCollectionExtensions.AddRepositoryApiClient"/> creates a single
+        /// <see cref="SharedCacheConfiguration"/> from the captured delegate and applies it to every typed client via
+        /// <see cref="ApiClientOptionsBuilder{TOptions,TBuilder}.WithSharedCaching(SharedCacheConfiguration)"/>, which
+        /// natively scopes operations to the current typed client and skips unrelated siblings. Library defaults registered
+        /// via <see cref="MX.Api.Client.Extensions.ApiClientExtensions.AddDefaultCachePolicies{TClient}"/> continue to
+        /// apply per typed client as designed.
         /// </para>
         /// </remarks>
         /// <param name="configure">The cache policy configuration callback.</param>
@@ -64,72 +74,8 @@ namespace XtremeIdiots.Portal.Repository.Api.Client.V1
         public new RepositoryApiOptionsBuilder WithCaching(Action<CacheBuilder> configure)
         {
             ArgumentNullException.ThrowIfNull(configure);
-
-            // Run the consumer's delegate against a fresh, unscoped shadow builder so any
-            // expression targeting any sub-API validates only against its own TApi/DeclaringType
-            // relationship and never against a mismatched _configuredClientType.
-            var shadow = new RepositoryApiOptionsBuilder();
-            _ = ((ApiClientOptionsBuilder<RepositoryApiClientOptions, RepositoryApiOptionsBuilder>)shadow)
-                .WithCaching(configure);
-
-            var shadowOptions = shadow.Options;
-
-            if (shadowOptions.UseLibraryCacheDefaults)
-            {
-                _ = base.WithCaching(static c => c.UseLibraryDefaults());
-            }
-
-            if (shadowOptions.CachePolicyOperations.Count == 0)
-            {
-                return this;
-            }
-
-            var currentTypedClient = ReadConfiguredClientType(this);
-
-            foreach (var kvp in shadowOptions.CachePolicyOperations)
-            {
-                var declaringType = kvp.Key.DeclaringType;
-                if (declaringType is null)
-                {
-                    continue;
-                }
-
-                if (currentTypedClient is not null && !declaringType.IsAssignableFrom(currentTypedClient))
-                {
-                    // Expression targets a different sub-API contract than the typed client
-                    // currently being configured. Skip - it will be applied when the matching
-                    // typed client's builder pass runs.
-                    continue;
-                }
-
-                ApplyCachePolicyOperation(Options, kvp.Key, kvp.Value);
-            }
-
+            CapturedCacheConfigure = configure;
             return this;
         }
-
-        private static readonly FieldInfo ConfiguredClientTypeField = typeof(ApiClientOptionsBuilder<RepositoryApiClientOptions, RepositoryApiOptionsBuilder>)
-            .GetField("_configuredClientType", BindingFlags.Instance | BindingFlags.NonPublic)
-            ?? throw new InvalidOperationException(
-                "MX.Api.Client contract change: expected private field '_configuredClientType' on ApiClientOptionsBuilder<,> was not found. "
-                + "Repository client cache scoping cannot be applied safely without it.");
-
-        private static readonly MethodInfo SetCachePolicyOperationMethod = typeof(ApiClientOptionsBase)
-            .GetMethod(
-                "SetCachePolicyOperation",
-                BindingFlags.Instance | BindingFlags.NonPublic,
-                binder: null,
-                types: new[] { typeof(MethodInfo), typeof(CachePolicyOperation) },
-                modifiers: null)
-            ?? throw new InvalidOperationException(
-                "MX.Api.Client contract change: expected internal method 'ApiClientOptionsBase.SetCachePolicyOperation(MethodInfo, CachePolicyOperation)' was not found. "
-                + "Repository client cache scoping cannot be applied safely without it.");
-
-        private static Type? ReadConfiguredClientType(RepositoryApiOptionsBuilder builder)
-            => (Type?)ConfiguredClientTypeField.GetValue(builder);
-
-        private static void ApplyCachePolicyOperation(ApiClientOptionsBase options, MethodInfo method, CachePolicyOperation operation)
-            => SetCachePolicyOperationMethod.Invoke(options, new object[] { method, operation });
     }
 }
-

--- a/src/XtremeIdiots.Portal.Repository.Api.Client.V1/RepositoryApiOptionsBuilder.cs
+++ b/src/XtremeIdiots.Portal.Repository.Api.Client.V1/RepositoryApiOptionsBuilder.cs
@@ -1,3 +1,8 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+
 using MX.Api.Client.Configuration;
 
 namespace XtremeIdiots.Portal.Repository.Api.Client.V1
@@ -33,5 +38,100 @@ namespace XtremeIdiots.Portal.Repository.Api.Client.V1
             Options.EnableCaching = enableCaching;
             return this;
         }
+
+        /// <summary>
+        /// Configures caching for the Repository API client with cross-sub-API scope isolation.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// The <see cref="ServiceCollectionExtensions.AddRepositoryApiClient"/> registration
+        /// re-invokes the consumer's configuration delegate once per typed sub-API
+        /// (<see cref="Abstractions.Interfaces.V1.IAdminActionsApi"/>,
+        /// <see cref="Abstractions.Interfaces.V1.IGameServersApi"/>, etc.). MX.Api.Client 2.3.76
+        /// scopes each builder to a single typed client, so an expression such as
+        /// <c>c.NotCached&lt;IGameServersApi, ...&gt;(x =&gt; x.GetGameServer(...))</c> would throw
+        /// <see cref="ArgumentException"/> when replayed against every non-matching typed client.
+        /// </para>
+        /// <para>
+        /// This override captures the consumer's intent once against an unscoped shadow builder,
+        /// then replays only the operations whose declaring interface is assignable to the
+        /// currently-configured typed client, preserving library-default opt-in and consumer
+        /// overrides while eliminating the cross-client crash. Library defaults registered via
+        /// <see cref="MX.Api.Client.Extensions.ApiClientExtensions.AddDefaultCachePolicies{TClient}"/>
+        /// continue to apply per typed client as designed.
+        /// </para>
+        /// </remarks>
+        /// <param name="configure">The cache policy configuration callback.</param>
+        /// <returns>The builder for chaining.</returns>
+        public new RepositoryApiOptionsBuilder WithCaching(Action<CacheBuilder> configure)
+        {
+            ArgumentNullException.ThrowIfNull(configure);
+
+            // Run the consumer's delegate against a fresh, unscoped shadow builder so any
+            // expression targeting any sub-API validates only against its own TApi/DeclaringType
+            // relationship and never against a mismatched _configuredClientType.
+            var shadow = new RepositoryApiOptionsBuilder();
+            _ = ((ApiClientOptionsBuilder<RepositoryApiClientOptions, RepositoryApiOptionsBuilder>)shadow)
+                .WithCaching(configure);
+
+            var shadowOptions = shadow.Options;
+
+            if (shadowOptions.UseLibraryCacheDefaults)
+            {
+                _ = base.WithCaching(static c => c.UseLibraryDefaults());
+            }
+
+            if (shadowOptions.CachePolicyOperations.Count == 0)
+            {
+                return this;
+            }
+
+            var currentTypedClient = ReadConfiguredClientType(this);
+
+            foreach (var kvp in shadowOptions.CachePolicyOperations)
+            {
+                var declaringType = kvp.Key.DeclaringType;
+                if (declaringType is null)
+                {
+                    continue;
+                }
+
+                if (currentTypedClient is not null && !declaringType.IsAssignableFrom(currentTypedClient))
+                {
+                    // Expression targets a different sub-API contract than the typed client
+                    // currently being configured. Skip - it will be applied when the matching
+                    // typed client's builder pass runs.
+                    continue;
+                }
+
+                ApplyCachePolicyOperation(Options, kvp.Key, kvp.Value);
+            }
+
+            return this;
+        }
+
+        private static readonly FieldInfo ConfiguredClientTypeField = typeof(ApiClientOptionsBuilder<RepositoryApiClientOptions, RepositoryApiOptionsBuilder>)
+            .GetField("_configuredClientType", BindingFlags.Instance | BindingFlags.NonPublic)
+            ?? throw new InvalidOperationException(
+                "MX.Api.Client contract change: expected private field '_configuredClientType' on ApiClientOptionsBuilder<,> was not found. "
+                + "Repository client cache scoping cannot be applied safely without it.");
+
+        private static readonly MethodInfo SetCachePolicyOperationMethod = typeof(ApiClientOptionsBase)
+            .GetMethod(
+                "SetCachePolicyOperation",
+                BindingFlags.Instance | BindingFlags.NonPublic,
+                binder: null,
+                types: new[] { typeof(MethodInfo), typeof(CachePolicyOperation) },
+                modifiers: null)
+            ?? throw new InvalidOperationException(
+                "MX.Api.Client contract change: expected internal method 'ApiClientOptionsBase.SetCachePolicyOperation(MethodInfo, CachePolicyOperation)' was not found. "
+                + "Repository client cache scoping cannot be applied safely without it.");
+
+        private static Type? ReadConfiguredClientType(RepositoryApiOptionsBuilder builder)
+            => (Type?)ConfiguredClientTypeField.GetValue(builder);
+
+        private static void ApplyCachePolicyOperation(ApiClientOptionsBase options, MethodInfo method, CachePolicyOperation operation)
+            => SetCachePolicyOperationMethod.Invoke(options, new object[] { method, operation });
     }
 }
+

--- a/src/XtremeIdiots.Portal.Repository.Api.Client.V1/ServiceCollectionExtensions.cs
+++ b/src/XtremeIdiots.Portal.Repository.Api.Client.V1/ServiceCollectionExtensions.cs
@@ -1,4 +1,5 @@
 using Microsoft.Extensions.DependencyInjection;
+using MX.Api.Client.Configuration;
 using MX.Api.Client.Extensions;
 using XtremeIdiots.Portal.Repository.Abstractions.Interfaces.V1;
 using XtremeIdiots.Portal.Repository.Api.Client.V1.Caching;
@@ -17,6 +18,32 @@ namespace XtremeIdiots.Portal.Repository.Api.Client.V1
             this IServiceCollection serviceCollection,
             Action<RepositoryApiOptionsBuilder> configureOptions)
         {
+            ArgumentNullException.ThrowIfNull(serviceCollection);
+            ArgumentNullException.ThrowIfNull(configureOptions);
+
+            // Run configureOptions once against a throwaway probe to extract any caching delegate the
+            // consumer captured through RepositoryApiOptionsBuilder.WithCaching(Action<CacheBuilder>).
+            // The probe's remaining state is discarded - only the captured cache delegate is reused.
+            var probe = new RepositoryApiOptionsBuilder();
+            configureOptions(probe);
+            var capturedCache = probe.CapturedCacheConfigure;
+
+            // One SharedCacheConfiguration per AddRepositoryApiClient invocation, shared across every
+            // typed sub-API registration. The library scopes operations per typed client at apply time
+            // and skips non-matching siblings; ValidateAllOperationsMatched() below guards against typos
+            // (an expression that never matched any registered typed client).
+            var sharedCache = capturedCache is null
+                ? null
+                : new SharedCacheConfiguration(capturedCache);
+
+            Action<RepositoryApiOptionsBuilder> perClient = sharedCache is null
+                ? configureOptions
+                : builder =>
+                {
+                    configureOptions(builder);
+                    builder.WithSharedCaching(sharedCache);
+                };
+
             // Register library default cache policies per sub-API interface (the same interface
             // supplied to AddTypedApiClient below). Consumers opt in per client with
             // UseLibraryDefaults() on their CacheBuilder.
@@ -27,47 +54,53 @@ namespace XtremeIdiots.Portal.Repository.Api.Client.V1
             serviceCollection.AddDefaultCachePolicies<IApiHealthApi>(RepositoryApiCacheDefaults.ConfigureApiHealth);
 
             // Register V1 API implementations using the new typed pattern
-            serviceCollection.AddTypedApiClient<IAdminActionsApi, AdminActionsApi, RepositoryApiClientOptions, RepositoryApiOptionsBuilder>(configureOptions);
-            serviceCollection.AddTypedApiClient<IBanFileMonitorsApi, BanFileMonitorsApi, RepositoryApiClientOptions, RepositoryApiOptionsBuilder>(configureOptions);
-            serviceCollection.AddTypedApiClient<ICentralBanFileStatusApi, CentralBanFileStatusApi, RepositoryApiClientOptions, RepositoryApiOptionsBuilder>(configureOptions);
-            serviceCollection.AddTypedApiClient<IChatMessagesApi, ChatMessagesApi, RepositoryApiClientOptions, RepositoryApiOptionsBuilder>(configureOptions);
-            serviceCollection.AddTypedApiClient<IDataMaintenanceApi, DataMaintenanceApi, RepositoryApiClientOptions, RepositoryApiOptionsBuilder>(configureOptions);
-            serviceCollection.AddTypedApiClient<IDemosApi, DemosApi, RepositoryApiClientOptions, RepositoryApiOptionsBuilder>(configureOptions);
-            serviceCollection.AddTypedApiClient<IGameServersApi, GameServersApi, RepositoryApiClientOptions, RepositoryApiOptionsBuilder>(configureOptions);
-            serviceCollection.AddTypedApiClient<IGameServersEventsApi, GameServersEventsApi, RepositoryApiClientOptions, RepositoryApiOptionsBuilder>(configureOptions);
-            serviceCollection.AddTypedApiClient<IGameServersStatsApi, GameServersStatsApi, RepositoryApiClientOptions, RepositoryApiOptionsBuilder>(configureOptions);
-            serviceCollection.AddTypedApiClient<IGameTrackerBannerApi, GameTrackerBannerApi, RepositoryApiClientOptions, RepositoryApiOptionsBuilder>(configureOptions);
-            serviceCollection.AddTypedApiClient<IMapsApi, MapsApi, RepositoryApiClientOptions, RepositoryApiOptionsBuilder>(configureOptions);
-            serviceCollection.AddTypedApiClient<IConnectedPlayersApi, ConnectedPlayersApi, RepositoryApiClientOptions, RepositoryApiOptionsBuilder>(configureOptions);
+            serviceCollection.AddTypedApiClient<IAdminActionsApi, AdminActionsApi, RepositoryApiClientOptions, RepositoryApiOptionsBuilder>(perClient);
+            serviceCollection.AddTypedApiClient<IBanFileMonitorsApi, BanFileMonitorsApi, RepositoryApiClientOptions, RepositoryApiOptionsBuilder>(perClient);
+            serviceCollection.AddTypedApiClient<ICentralBanFileStatusApi, CentralBanFileStatusApi, RepositoryApiClientOptions, RepositoryApiOptionsBuilder>(perClient);
+            serviceCollection.AddTypedApiClient<IChatMessagesApi, ChatMessagesApi, RepositoryApiClientOptions, RepositoryApiOptionsBuilder>(perClient);
+            serviceCollection.AddTypedApiClient<IDataMaintenanceApi, DataMaintenanceApi, RepositoryApiClientOptions, RepositoryApiOptionsBuilder>(perClient);
+            serviceCollection.AddTypedApiClient<IDemosApi, DemosApi, RepositoryApiClientOptions, RepositoryApiOptionsBuilder>(perClient);
+            serviceCollection.AddTypedApiClient<IGameServersApi, GameServersApi, RepositoryApiClientOptions, RepositoryApiOptionsBuilder>(perClient);
+            serviceCollection.AddTypedApiClient<IGameServersEventsApi, GameServersEventsApi, RepositoryApiClientOptions, RepositoryApiOptionsBuilder>(perClient);
+            serviceCollection.AddTypedApiClient<IGameServersStatsApi, GameServersStatsApi, RepositoryApiClientOptions, RepositoryApiOptionsBuilder>(perClient);
+            serviceCollection.AddTypedApiClient<IGameTrackerBannerApi, GameTrackerBannerApi, RepositoryApiClientOptions, RepositoryApiOptionsBuilder>(perClient);
+            serviceCollection.AddTypedApiClient<IMapsApi, MapsApi, RepositoryApiClientOptions, RepositoryApiOptionsBuilder>(perClient);
+            serviceCollection.AddTypedApiClient<IConnectedPlayersApi, ConnectedPlayersApi, RepositoryApiClientOptions, RepositoryApiOptionsBuilder>(perClient);
 
-            serviceCollection.AddTypedApiClient<IPlayerAnalyticsApi, PlayerAnalyticsApi, RepositoryApiClientOptions, RepositoryApiOptionsBuilder>(configureOptions);
-            serviceCollection.AddTypedApiClient<IPlayersApi, PlayersApi, RepositoryApiClientOptions, RepositoryApiOptionsBuilder>(configureOptions);
-            serviceCollection.AddTypedApiClient<IRecentPlayersApi, RecentPlayersApi, RepositoryApiClientOptions, RepositoryApiOptionsBuilder>(configureOptions);
-            serviceCollection.AddTypedApiClient<IReportsApi, ReportsApi, RepositoryApiClientOptions, RepositoryApiOptionsBuilder>(configureOptions);
-            serviceCollection.AddTypedApiClient<ITagsApi, TagsApi, RepositoryApiClientOptions, RepositoryApiOptionsBuilder>(configureOptions);
-            serviceCollection.AddTypedApiClient<IUserProfileApi, UserProfileApi, RepositoryApiClientOptions, RepositoryApiOptionsBuilder>(configureOptions);
+            serviceCollection.AddTypedApiClient<IPlayerAnalyticsApi, PlayerAnalyticsApi, RepositoryApiClientOptions, RepositoryApiOptionsBuilder>(perClient);
+            serviceCollection.AddTypedApiClient<IPlayersApi, PlayersApi, RepositoryApiClientOptions, RepositoryApiOptionsBuilder>(perClient);
+            serviceCollection.AddTypedApiClient<IRecentPlayersApi, RecentPlayersApi, RepositoryApiClientOptions, RepositoryApiOptionsBuilder>(perClient);
+            serviceCollection.AddTypedApiClient<IReportsApi, ReportsApi, RepositoryApiClientOptions, RepositoryApiOptionsBuilder>(perClient);
+            serviceCollection.AddTypedApiClient<ITagsApi, TagsApi, RepositoryApiClientOptions, RepositoryApiOptionsBuilder>(perClient);
+            serviceCollection.AddTypedApiClient<IUserProfileApi, UserProfileApi, RepositoryApiClientOptions, RepositoryApiOptionsBuilder>(perClient);
 
             // Register API info endpoint
-            serviceCollection.AddTypedApiClient<IApiInfoApi, ApiInfoApi, RepositoryApiClientOptions, RepositoryApiOptionsBuilder>(configureOptions);
+            serviceCollection.AddTypedApiClient<IApiInfoApi, ApiInfoApi, RepositoryApiClientOptions, RepositoryApiOptionsBuilder>(perClient);
 
             // Register API health endpoint
-            serviceCollection.AddTypedApiClient<IApiHealthApi, ApiHealthApi, RepositoryApiClientOptions, RepositoryApiOptionsBuilder>(configureOptions);
+            serviceCollection.AddTypedApiClient<IApiHealthApi, ApiHealthApi, RepositoryApiClientOptions, RepositoryApiOptionsBuilder>(perClient);
 
             // Register Notification API implementations
-            serviceCollection.AddTypedApiClient<INotificationTypesApi, NotificationTypesApi, RepositoryApiClientOptions, RepositoryApiOptionsBuilder>(configureOptions);
-            serviceCollection.AddTypedApiClient<INotificationPreferencesApi, NotificationPreferencesApi, RepositoryApiClientOptions, RepositoryApiOptionsBuilder>(configureOptions);
-            serviceCollection.AddTypedApiClient<INotificationsApi, NotificationsApi, RepositoryApiClientOptions, RepositoryApiOptionsBuilder>(configureOptions);
-            serviceCollection.AddTypedApiClient<IMapRotationsApi, MapRotationsApi, RepositoryApiClientOptions, RepositoryApiOptionsBuilder>(configureOptions);
-            serviceCollection.AddTypedApiClient<IDashboardApi, DashboardApi, RepositoryApiClientOptions, RepositoryApiOptionsBuilder>(configureOptions);
-            serviceCollection.AddTypedApiClient<IGlobalConfigurationsApi, GlobalConfigurationsApi, RepositoryApiClientOptions, RepositoryApiOptionsBuilder>(configureOptions);
-            serviceCollection.AddTypedApiClient<IGameServerConfigurationsApi, GameServerConfigurationsApi, RepositoryApiClientOptions, RepositoryApiOptionsBuilder>(configureOptions);
-            serviceCollection.AddTypedApiClient<ILiveStatusApi, LiveStatusApi, RepositoryApiClientOptions, RepositoryApiOptionsBuilder>(configureOptions);
-            serviceCollection.AddTypedApiClient<IGlobalAnalyticsApi, GlobalAnalyticsApi, RepositoryApiClientOptions, RepositoryApiOptionsBuilder>(configureOptions);
-            serviceCollection.AddTypedApiClient<IGameAnalyticsApi, GameAnalyticsApi, RepositoryApiClientOptions, RepositoryApiOptionsBuilder>(configureOptions);
-            serviceCollection.AddTypedApiClient<IServerAnalyticsApi, ServerAnalyticsApi, RepositoryApiClientOptions, RepositoryApiOptionsBuilder>(configureOptions);
-            serviceCollection.AddTypedApiClient<IDashboardAnalyticsApi, DashboardAnalyticsApi, RepositoryApiClientOptions, RepositoryApiOptionsBuilder>(configureOptions);
-            serviceCollection.AddTypedApiClient<IMapAnalyticsApi, MapAnalyticsApi, RepositoryApiClientOptions, RepositoryApiOptionsBuilder>(configureOptions);
-            serviceCollection.AddTypedApiClient<IPlayerAnalyticsV2Api, PlayerAnalyticsV2Api, RepositoryApiClientOptions, RepositoryApiOptionsBuilder>(configureOptions);
+            serviceCollection.AddTypedApiClient<INotificationTypesApi, NotificationTypesApi, RepositoryApiClientOptions, RepositoryApiOptionsBuilder>(perClient);
+            serviceCollection.AddTypedApiClient<INotificationPreferencesApi, NotificationPreferencesApi, RepositoryApiClientOptions, RepositoryApiOptionsBuilder>(perClient);
+            serviceCollection.AddTypedApiClient<INotificationsApi, NotificationsApi, RepositoryApiClientOptions, RepositoryApiOptionsBuilder>(perClient);
+            serviceCollection.AddTypedApiClient<IMapRotationsApi, MapRotationsApi, RepositoryApiClientOptions, RepositoryApiOptionsBuilder>(perClient);
+            serviceCollection.AddTypedApiClient<IDashboardApi, DashboardApi, RepositoryApiClientOptions, RepositoryApiOptionsBuilder>(perClient);
+            serviceCollection.AddTypedApiClient<IGlobalConfigurationsApi, GlobalConfigurationsApi, RepositoryApiClientOptions, RepositoryApiOptionsBuilder>(perClient);
+            serviceCollection.AddTypedApiClient<IGameServerConfigurationsApi, GameServerConfigurationsApi, RepositoryApiClientOptions, RepositoryApiOptionsBuilder>(perClient);
+            serviceCollection.AddTypedApiClient<ILiveStatusApi, LiveStatusApi, RepositoryApiClientOptions, RepositoryApiOptionsBuilder>(perClient);
+            serviceCollection.AddTypedApiClient<IGlobalAnalyticsApi, GlobalAnalyticsApi, RepositoryApiClientOptions, RepositoryApiOptionsBuilder>(perClient);
+            serviceCollection.AddTypedApiClient<IGameAnalyticsApi, GameAnalyticsApi, RepositoryApiClientOptions, RepositoryApiOptionsBuilder>(perClient);
+            serviceCollection.AddTypedApiClient<IServerAnalyticsApi, ServerAnalyticsApi, RepositoryApiClientOptions, RepositoryApiOptionsBuilder>(perClient);
+            serviceCollection.AddTypedApiClient<IDashboardAnalyticsApi, DashboardAnalyticsApi, RepositoryApiClientOptions, RepositoryApiOptionsBuilder>(perClient);
+            serviceCollection.AddTypedApiClient<IMapAnalyticsApi, MapAnalyticsApi, RepositoryApiClientOptions, RepositoryApiOptionsBuilder>(perClient);
+            serviceCollection.AddTypedApiClient<IPlayerAnalyticsV2Api, PlayerAnalyticsV2Api, RepositoryApiClientOptions, RepositoryApiOptionsBuilder>(perClient);
+
+            // Once every typed sub-API has been registered, verify every operation captured on the
+            // shared cache configuration matched at least one registered typed client. Throws
+            // InvalidOperationException on orphaned operations (e.g. a consumer expression that
+            // targets an interface which is not a registered Repository sub-API).
+            sharedCache?.ValidateAllOperationsMatched();
 
             // Register version selectors as scoped
             serviceCollection.AddScoped<IVersionedAdminActionsApi, VersionedAdminActionsApi>();

--- a/src/XtremeIdiots.Portal.Repository.Api.Client.V1/XtremeIdiots.Portal.Repository.Api.Client.V1.csproj
+++ b/src/XtremeIdiots.Portal.Repository.Api.Client.V1/XtremeIdiots.Portal.Repository.Api.Client.V1.csproj
@@ -20,8 +20,8 @@
     <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="10.0.10" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.10" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.10" />
-    <PackageReference Include="MX.Api.Client" Version="2.3.76" />
-    <PackageReference Include="MX.Api.Abstractions" Version="2.3.76" />
+    <PackageReference Include="MX.Api.Client" Version="2.3.77" />
+    <PackageReference Include="MX.Api.Abstractions" Version="2.3.77" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageReference Include="RestSharp" Version="114.0.0" />
   </ItemGroup>

--- a/src/XtremeIdiots.Portal.Repository.Api.Client.V2/XtremeIdiots.Portal.Repository.Api.Client.V2.csproj
+++ b/src/XtremeIdiots.Portal.Repository.Api.Client.V2/XtremeIdiots.Portal.Repository.Api.Client.V2.csproj
@@ -21,8 +21,8 @@
     <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="10.0.10" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.10" />
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.10" />
-    <PackageReference Include="MX.Api.Client" Version="2.3.76" />
-    <PackageReference Include="MX.Api.Abstractions" Version="2.3.76" />
+    <PackageReference Include="MX.Api.Client" Version="2.3.77" />
+    <PackageReference Include="MX.Api.Abstractions" Version="2.3.77" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageReference Include="RestSharp" Version="114.0.0" />
   </ItemGroup>

--- a/src/XtremeIdiots.Portal.Repository.Api.V1/XtremeIdiots.Portal.Repository.Api.V1.csproj
+++ b/src/XtremeIdiots.Portal.Repository.Api.V1/XtremeIdiots.Portal.Repository.Api.V1.csproj
@@ -24,7 +24,7 @@
     <PackageReference Include="Microsoft.Data.SqlClient" Version="7.0.2" />
     <PackageReference Include="Microsoft.Data.SqlClient.Extensions.Azure" Version="7.0.2" />
     <PackageReference Include="Microsoft.Identity.Web" Version="4.14.2" />
-    <PackageReference Include="MX.Api.Abstractions" Version="2.3.76" />
+    <PackageReference Include="MX.Api.Abstractions" Version="2.3.77" />
     <PackageReference Include="MX.Api.Web.Extensions" Version="2.3.76" />
     <PackageReference Include="MX.Caching" Version="0.1.6" />
     <PackageReference Include="MX.Caching.Abstractions" Version="0.1.6" />

--- a/src/XtremeIdiots.Portal.Repository.Api.V2/XtremeIdiots.Portal.Repository.Api.V2.csproj
+++ b/src/XtremeIdiots.Portal.Repository.Api.V2/XtremeIdiots.Portal.Repository.Api.V2.csproj
@@ -23,7 +23,7 @@
     <PackageReference Include="Microsoft.Data.SqlClient" Version="7.0.2" />
     <PackageReference Include="Microsoft.Data.SqlClient.Extensions.Azure" Version="7.0.2" />
     <PackageReference Include="Microsoft.Identity.Web" Version="4.14.2" />
-    <PackageReference Include="MX.Api.Abstractions" Version="2.3.76" />
+    <PackageReference Include="MX.Api.Abstractions" Version="2.3.77" />
     <PackageReference Include="MX.Api.Web.Extensions" Version="2.3.76" />
     <PackageReference Include="MX.Observability.ApplicationInsights.AspNetCore" Version="1.1.28" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />


### PR DESCRIPTION
## Summary

Fix the startup `ArgumentException` seen by consumers that enabled `.WithCaching(c => c.UseLibraryDefaults())` on `AddRepositoryApiClient` (regression exposed in 4.2.21 on MX.Api.Client 2.3.76). This revision replaces the earlier private-reflection cache-scoping fix with MX.Api.Client **2.3.77**'s new first-class `SharedCacheConfiguration` / `WithSharedCaching` API. All reflection into MX internals is gone.

Closes #4221

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Dependency bump (MX.Api.Client 2.3.76 → 2.3.77 across all consuming projects for solution-wide version consistency)

## Root cause

`ApiClientOptionsBuilder<TOptions,TBuilder>.WithCaching(Action<CacheBuilder>)` (2.3.76) evaluates every cache expression the consumer supplies against the currently-scoped typed client's interface and throws `ArgumentException: The expression must invoke a method declared by ... IAdminActionsApi or inherited interfaces` when the expression's declaring interface isn't assignable to the scoped client. `AddRepositoryApiClient` invokes the same consumer `configureOptions` delegate for every one of ~34 `AddTypedApiClient` registrations, so a single consumer `.WithCaching(...)` call containing operations for multiple sub-APIs unavoidably crashes on the first mismatched sibling.

## Fix

MX.Api.Client 2.3.77 shipped a purpose-built API for the unified-client scenario. Repository consumes it:

1. **`RepositoryApiOptionsBuilder.WithCaching(Action<CacheBuilder>)`** now only **captures** the consumer delegate onto an internal `CapturedCacheConfigure` property. It never throws and never applies operations itself. All private reflection into MX (`_configuredClientType`, `SetCachePolicyOperation`) is removed.
2. **`ServiceCollectionExtensions.AddRepositoryApiClient`** runs `configureOptions` once against a throwaway probe builder to extract `CapturedCacheConfigure`, then constructs **one** `SharedCacheConfiguration` for the composition. A `perClient` wrapper invokes `configureOptions(builder)` and then `builder.WithSharedCaching(sharedCache)`. `WithSharedCaching` applies only the operations whose declaring interface is assignable from the currently-scoped typed client and **skips siblings instead of throwing**. After all typed clients are registered, `sharedCache?.ValidateAllOperationsMatched()` is invoked **exactly once** — this surfaces genuine consumer typos (a cache expression targeting an interface that is not a registered Repository sub-API) as a clear `InvalidOperationException`.
3. Existing `AddDefaultCachePolicies<TClient>` calls and the safe policy matrix are unchanged.

The consumer-facing surface is unchanged: `.WithCaching(c => c.UseLibraryDefaults()....)` continues to work exactly as documented. `SharedCacheConfiguration` is a Repository-side implementation detail.

## Consumer impact

- **Public API unchanged.** Consumers still call `.WithCaching(c => c.UseLibraryDefaults()....)` — no code change required in downstream consumers.
- Consumers on the fixed package will additionally get a clear `InvalidOperationException` at startup if their cache expression targets an interface that is not a registered Repository sub-API (previously such typos would be silently mapped to the wrong client). This is intentional and matches the shipping MX.Api.Client 2.3.77 contract.
- MX.Api.Client and MX.Api.Abstractions bumped 2.3.76 → 2.3.77 across V1/V2 Client, Abstractions V1/V2, Api V1/V2, and Client.Testing csprojs. No functional caching change in V2 — the bump is version-consistency only.
- `Api.Client.Testing` package: no in-memory fake or DTO factory changed; version bump is transitive-consistency only.

## Validation evidence

**Build** (`dotnet build src/XtremeIdiots.Portal.Repository.sln`):

```
Build succeeded.
    0 Warning(s)
    0 Error(s)

Time Elapsed 00:00:16.15
```

**Tests** (`dotnet test src/XtremeIdiots.Portal.Repository.sln --filter "FullyQualifiedName!~IntegrationTests"`) — all 12 non-integration assemblies pass on net9.0 and net10.0:

```
Passed!  - Failed: 0, Passed:  86, Skipped:  0, Total:  86  XtremeIdiots.Portal.Repository.Api.Client.Tests.V1.dll (net10.0)
Passed!  - Failed: 0, Passed:  86, Skipped:  0, Total:  86  XtremeIdiots.Portal.Repository.Api.Client.Tests.V1.dll (net9.0)
Passed!  - Failed: 0, Passed:   9, Skipped:  0, Total:   9  XtremeIdiots.Portal.Repository.Api.Tests.V2.dll (net9.0)
Passed!  - Failed: 0, Passed:  44, Skipped:  0, Total:  44  XtremeIdiots.Portal.Settings.Contracts.V1.Tests.dll (net10.0)
Passed!  - Failed: 0, Passed:  44, Skipped:  0, Total:  44  XtremeIdiots.Portal.Settings.Contracts.V1.Tests.dll (net9.0)
Passed!  - Failed: 0, Passed:  72, Skipped:  0, Total:  72  XtremeIdiots.Portal.Repository.Api.Client.Testing.Tests.dll (net10.0)
Passed!  - Failed: 0, Passed:   9, Skipped:  0, Total:   9  XtremeIdiots.Portal.Repository.Api.Tests.V2.dll (net10.0)
Passed!  - Failed: 0, Passed:  14, Skipped:  0, Total:  14  XtremeIdiots.Portal.Repository.Api.Client.Tests.V2.dll (net9.0)
Passed!  - Failed: 0, Passed:  14, Skipped:  0, Total:  14  XtremeIdiots.Portal.Repository.Api.Client.Tests.V2.dll (net10.0)
Passed!  - Failed: 0, Passed:  72, Skipped:  0, Total:  72  XtremeIdiots.Portal.Repository.Api.Client.Testing.Tests.dll (net9.0)
Passed!  - Failed: 0, Passed: 462, Skipped: 10, Total: 472  XtremeIdiots.Portal.Repository.Api.Tests.V1.dll (net9.0)
Passed!  - Failed: 0, Passed: 462, Skipped: 10, Total: 472  XtremeIdiots.Portal.Repository.Api.Tests.V1.dll (net10.0)
```

The Repository client test suite covers:
- All 34 sub-API interfaces resolve after `AddRepositoryApiClient` + `BuildServiceProvider()` (theory over `AllSubApiInterfaces`).
- A consumer `WithCaching` override targeting one sub-API lands only on that typed client's registered options (no cross-client bleed).
- **New**: a cache expression targeting an interface that is not a registered Repository sub-API (`INotARegisteredRepositoryApi`) triggers `ValidateAllOperationsMatched()` → `InvalidOperationException` at startup.

**Format** (`dotnet format src/XtremeIdiots.Portal.Repository.sln --verify-no-changes`): clean (no changes required).

**Code-review sub-agent**: no significant issues. Confirmed (a) probe pattern is side-effect free because the overridden `WithCaching` only stores the delegate, (b) `ValidateAllOperationsMatched()` runs after every typed client has been visited because `AddTypedApiClient` invokes the configure delegate eagerly at registration time, (c) `WithSharedCaching` composes correctly with the pre-existing `AddDefaultCachePolicies<T>` singleton lookup.

## Risk and rollout

- **Blast radius**: bug fix in the V1 Repository client NuGet package + solution-wide MX.Api.Client version bump 2.3.76 → 2.3.77. No API host runtime behavior change beyond consuming the newer MX library.
- **Auto-deploy**: standard NBGV / release workflow. Expected version 4.2.22 (patch bump from git height — `version.json` untouched).
- **Manual steps post-merge**: none for API hosts. Consumers of `XtremeIdiots.Portal.Repository.Api.Client.V1` should upgrade to the new package to pick up the fix.
- **Rollback**: revert this commit. Consumers can pin to 4.2.20 or earlier if they need to roll back to the pre-regression behavior.

## Agent attestation

- [x] I read the required files listed in `AGENTS.md` before starting work.
- [x] I ran the pre-PR check commands locally and pasted their real output above.
- [x] No secrets, connection strings, or credentials were introduced.
- [x] No changes to `version.json`, `Directory.Build.props`, or `.github/workflows/`.
- [x] No hand edits to `DataLib` (no schema change; regeneration not required).
- [x] APIM API definitions are not managed by Terraform in this change.
- [x] All published contract surfaces (`.WithCaching(Action<CacheBuilder>)`, `RepositoryApiOptionsBuilder`) remain source-compatible.
- [x] `code-review` sub-agent run; no High/Medium findings.
- [x] Zero reflection into MX.Api.Client internals remains in `src/XtremeIdiots.Portal.Repository.Api.Client.V1/` (verified by grep).