### PR TITLE
docs: document label-driven route-to-live (health check + dev-deploy validation)

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,14 @@ Versioned ASP.NET Core APIs power player, server, map, and telemetry flows for t
 | [`XtremeIdiots.Portal.Repository.Api.Client.V2`](https://www.nuget.org/packages/XtremeIdiots.Portal.Repository.Api.Client.V2)           | [![NuGet](https://img.shields.io/nuget/v/XtremeIdiots.Portal.Repository.Api.Client.V2.svg)](https://www.nuget.org/packages/XtremeIdiots.Portal.Repository.Api.Client.V2/)           | Typed client for Repository API V2                              |
 | [`XtremeIdiots.Portal.Repository.Api.Client.Testing`](https://www.nuget.org/packages/XtremeIdiots.Portal.Repository.Api.Client.Testing) | [![NuGet](https://img.shields.io/nuget/v/XtremeIdiots.Portal.Repository.Api.Client.Testing.svg)](https://www.nuget.org/packages/XtremeIdiots.Portal.Repository.Api.Client.Testing/) | In-memory fakes and test helpers for consumer integration tests |
 
+## Route to Live
+Deployment is driven by pull request labels on top of the standard PR Verify pipeline (build, test, and Terraform plan against Development run automatically on every non-draft PR):
+
+* **`deploy-dev`** — runs the Terraform plan+apply, SQL database deploy, and V1/V2 App Service deploys against the Development environment, then verifies the deployed build via the `/v1.0/info` and `/v2.0/info` endpoints. Dependabot PRs are intentionally excluded from the apply/deploy jobs.
+* **`run-prd-plan`** — runs a Terraform plan against the Production environment for review (no apply).
+
+Merges to `main` that touch `src/**` trigger the Release - Version and Tag workflow (Nerdbank.GitVersioning), which in turn publishes the API client NuGet packages via Release - Publish NuGet. Production infrastructure and app deployment run from the Deploy Prd workflow.
+
 ## Contributing
 Please read the [contributing](CONTRIBUTING.md) guidance; this is a learning and development project.
 


### PR DESCRIPTION
## Summary

Autonomous development & route-to-live health check for `portal-repository`. Adds a "Route to Live" section to the README documenting the label-driven deployment flow, and serves as the vehicle to validate the dev deployment pipeline end-to-end.

## Type of change

- [x] Documentation
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change

## Validation evidence

Local gates run against the solution before pushing:

- **Format**: `dotnet format src/XtremeIdiots.Portal.Repository.sln --verify-no-changes` → exit code `0` (no changes).
- **Build**: `dotnet build src/XtremeIdiots.Portal.Repository.sln -c Release` → `Build succeeded. 0 Warning(s) 0 Error(s)` (client NuGet packages packed cleanly).
- **Tests**: `dotnet test ... -c Release --filter "FullyQualifiedName!~IntegrationTests"` → all suites `Passed! Failed: 0` (e.g. Api.Tests.V1 462 passed/10 skipped; Client.Tests.V1 86 passed; Settings.Contracts.V1 44 passed; Api.Tests.V2 9 passed).

CI PR Verify (build-and-test + Code Quality) passes on this PR.

**Dev deployment validation (label `deploy-dev`, run [32183213452](https://github.com/frasermolyneux/portal-repository/actions/runs/32183213452)):** Terraform apply, SQL deploy, and V1/V2 App Service deploys **succeeded** (apps live, `/v1.0/info` & `/v2.0/info` return `4.2.26`). The final `wait-for-version` gate **failed deterministically** because feature-branch NBGV `build_version` (`4.2.26-g5c524acb34`) never matches the `/info` `BuildVersion` (`4.2.26`). This is a pre-existing limitation of PR-branch validation and does not affect main/prod deploys. See the pinned comment for root cause and remediation options — **left as draft + `needs-decision` for maintainer sign-off**.

## Risk and rollout

- **Blast radius**: Documentation only (`README.md`). No source, contract, workflow, Terraform, or `version.json` changes.
- **Auto-deploy?**: No auto-deploy on merge. The `deploy-dev` label was applied once to validate the Development route-to-live pipeline, then removed. The Development environment is recreated/destroyed on a schedule, so the apply is expected and non-destructive to production.
- **Manual steps post-merge**: None.
- **Rollback plan**: Revert the doc commit; no runtime impact.

## Consumer impact

No published contract changed (no Abstractions DTOs, no Client NuGet, no Service Bus DTO, no Terraform output). Documentation-only.

## Agent attestation

- [x] I followed the repo `AGENTS.md` / `copilot-instructions.md` conventions.
- [x] I ran `dotnet build`, unit `dotnet test`, and `dotnet format --verify-no-changes` locally and pasted real output above.
- [x] I did not commit to, merge into, or mutate `main`.
- [x] I did not introduce secrets, connection strings, or hard-coded GUIDs.
- [x] No published contract (Abstractions / Client NuGet / Service Bus DTO / Terraform output) changed.
- [x] No hand edits to `DataLib`; no schema change.
- [x] I did not change `version.json`, `Directory.Build.props`, or workflow behaviour.
